### PR TITLE
[no jira]: Deprecate button tokens as part of spacing upgrade

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,13 @@
+**Changed:**
+
+- bpk-foundations-web:
+  - The following button tokens are now deprecated. To migrate, use an equivalent spacing value.
+    - `$button-padding-x`
+    - `$button-padding-y`
+    - `$button-padding-x-icon-only`
+    - `$button-icon-border-radius`
+    - `$button-icon-border-radius-lg`
+    - `$button-large-padding-x`
+    - `$button-large-padding-y`
+    - `$button-large-padding-x-icon-only`
+  

--- a/packages/bpk-foundations-web/src/base/buttons.json
+++ b/packages/bpk-foundations-web/src/base/buttons.json
@@ -8,23 +8,28 @@
   "props": {
     "BUTTON_PADDING_Y": {
       "value": "{!SPACING_XS}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "BUTTON_PADDING_X": {
       "value": "{!SPACING_MD}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "BUTTON_PADDING_X_ICON_ONLY": {
       "value": ".5625rem",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "BUTTON_ICON_BORDER_RADIUS": {
       "value": "{!BORDER_RADIUS_PILL}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "BUTTON_ICON_BORDER_RADIUS_LG": {
       "value": "{!BORDER_RADIUS_PILL_LG}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "BUTTON_BORDER_RADIUS": {
       "value": "{!BORDER_RADIUS_SM}",
@@ -116,15 +121,18 @@
     },
     "BUTTON_LARGE_PADDING_Y": {
       "value": "{!SPACING_XS}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "BUTTON_LARGE_PADDING_X": {
       "value": "{!SPACING_BASE}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "BUTTON_LARGE_PADDING_X_ICON_ONLY": {
       "value": ".5625rem",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "BUTTON_LARGE_FONT_SIZE": {
       "value": "{!FONT_SIZE_XL}",

--- a/packages/bpk-foundations-web/tokens/base.raw.json
+++ b/packages/bpk-foundations-web/tokens/base.raw.json
@@ -816,6 +816,7 @@
       "category": "buttons",
       "value": "1.125rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!BORDER_RADIUS_PILL}",
       "name": "BUTTON_ICON_BORDER_RADIUS"
     },
@@ -837,6 +838,7 @@
       "category": "buttons",
       "value": ".5625rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": ".5625rem",
       "name": "BUTTON_LARGE_PADDING_X_ICON_ONLY"
     },
@@ -879,6 +881,7 @@
       "category": "buttons",
       "value": "1.3125rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!BORDER_RADIUS_PILL_LG}",
       "name": "BUTTON_ICON_BORDER_RADIUS_LG"
     },
@@ -908,6 +911,7 @@
       "category": "buttons",
       "value": ".5625rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": ".5625rem",
       "name": "BUTTON_PADDING_X_ICON_ONLY"
     },
@@ -1049,6 +1053,7 @@
       "category": "buttons",
       "value": "1.5rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_BASE}",
       "name": "BUTTON_LARGE_PADDING_X"
     },
@@ -1077,6 +1082,7 @@
       "category": "buttons",
       "value": ".375rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_XS}",
       "name": "BUTTON_LARGE_PADDING_Y"
     },
@@ -1168,6 +1174,7 @@
       "category": "buttons",
       "value": "1.125rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_MD}",
       "name": "BUTTON_PADDING_X"
     },
@@ -1182,6 +1189,7 @@
       "category": "buttons",
       "value": ".375rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_XS}",
       "name": "BUTTON_PADDING_Y"
     },


### PR DESCRIPTION
When we did the new spacing updates for the button component (https://github.com/Skyscanner/backpack/pull/2185) we never made the same token deprcations in foundations.

This PR solves that.