### PR TITLE
[KOA-3622]: Deprecate select tokens as part of spacing upgrade

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,10 @@
+**Changed:**
+
+- bpk-foundations-web:
+  - The following tokens are now deprecated. To migrate, use an equivalent spacing value.
+    - `$bpk-select-height`
+    - `$bpk-select-padding-top`
+    - `$bpk-select-padding-right`
+    - `$bpk-select-padding-bottom`
+    - `$bpk-select-padding-left`
+    - `$bpk-select-large-height`

--- a/packages/bpk-foundations-web/src/base/forms.json
+++ b/packages/bpk-foundations-web/src/base/forms.json
@@ -64,23 +64,28 @@
     },
     "SELECT_HEIGHT": {
       "value": "{!SPACING_XL}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "SELECT_PADDING_TOP": {
       "value": "{!SPACING_XS}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "SELECT_PADDING_RIGHT": {
       "value": "{!SPACING_LG}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "SELECT_PADDING_BOTTOM": {
       "value": "{!SPACING_XS}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "SELECT_PADDING_LEFT": {
       "value": "{!SPACING_SM}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "SELECT_BORDER_WIDTH": {
       "value": "{!ONE_PIXEL_REM}",
@@ -108,7 +113,8 @@
     },
     "SELECT_LARGE_HEIGHT": {
       "value": "{!SPACING_XXL} + {!SPACING_XS}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "LABEL_COLOR": {
       "value": "{!SKY_GRAY}",

--- a/packages/bpk-foundations-web/tokens/base.raw.json
+++ b/packages/bpk-foundations-web/tokens/base.raw.json
@@ -1778,6 +1778,7 @@
       "category": "forms",
       "value": ".375rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_XS}",
       "name": "SELECT_PADDING_TOP"
     },
@@ -1806,6 +1807,7 @@
       "category": "forms",
       "value": "2.250rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_XL}",
       "name": "SELECT_HEIGHT"
     },
@@ -1820,6 +1822,7 @@
       "category": "forms",
       "value": "1.875rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_LG}",
       "name": "SELECT_PADDING_RIGHT"
     },
@@ -1827,6 +1830,7 @@
       "category": "forms",
       "value": "2.625rem + .375rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_XXL} + {!SPACING_XS}",
       "name": "SELECT_LARGE_HEIGHT"
     },
@@ -1904,6 +1908,7 @@
       "category": "forms",
       "value": ".75rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_SM}",
       "name": "SELECT_PADDING_LEFT"
     },
@@ -1939,6 +1944,7 @@
       "category": "forms",
       "value": ".375rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_XS}",
       "name": "SELECT_PADDING_BOTTOM"
     },


### PR DESCRIPTION
As part of the update to https://github.com/Skyscanner/backpack/pull/2221 - Select spacing tokens update. 

As it was using bespoke tokens until now (e.g. $bpk-select-height), I removed this layer of abstraction so they just use the spacing tokens directly. I've also deprecated these no-longer-used tokens.