### PR TITLE
[KOA-3620]: Deprecated no longer required rating tokens

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,10 @@
+**Changed:**
 
+- @skyscanner/bpk-foundations-web:
+  - The following rating tokens are now deprecated. To migrate, use an equivalent spacing value
+    - `bpk-rating-base-width`
+    - `bpk-rating-base-height`
+    - `bpk-rating-sm-width`
+    - `bpk-rating-sm-height`
+    - `bpk-rating-lg-width`
+    - `bpk-rating-lg-height`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13803,7 +13803,6 @@
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -14028,8 +14027,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -14132,8 +14130,7 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },

--- a/packages/bpk-foundations-android/package-lock.json
+++ b/packages/bpk-foundations-android/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyscanner/bpk-foundations-android",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/bpk-foundations-ios/package-lock.json
+++ b/packages/bpk-foundations-ios/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "@skyscanner/bpk-foundations-ios",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@skyscanner/bpk-foundations-common": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-1.0.0.tgz",
-			"integrity": "sha512-rH79IdIzoU0Bjwz4aWh59pThIDLhmfNs8k8JrtrWkGN/SZIyJx6sdFAW+JaQcAlWHLea1vxJHxOkT09zYS5qFQ==",
-			"requires": {
-				"color": "^3.0.0"
-			}
-		},
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-1.0.0.tgz",
+      "integrity": "sha512-rH79IdIzoU0Bjwz4aWh59pThIDLhmfNs8k8JrtrWkGN/SZIyJx6sdFAW+JaQcAlWHLea1vxJHxOkT09zYS5qFQ==",
+      "requires": {
+        "color": "^3.0.0"
+      }
+    },
 		"color": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",

--- a/packages/bpk-foundations-react-native/package-lock.json
+++ b/packages/bpk-foundations-react-native/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "@skyscanner/bpk-foundations-react-native",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@skyscanner/bpk-foundations-common": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-1.0.0.tgz",
-			"integrity": "sha512-rH79IdIzoU0Bjwz4aWh59pThIDLhmfNs8k8JrtrWkGN/SZIyJx6sdFAW+JaQcAlWHLea1vxJHxOkT09zYS5qFQ==",
-			"requires": {
-				"color": "^3.0.0"
-			}
-		},
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-1.0.0.tgz",
+      "integrity": "sha512-rH79IdIzoU0Bjwz4aWh59pThIDLhmfNs8k8JrtrWkGN/SZIyJx6sdFAW+JaQcAlWHLea1vxJHxOkT09zYS5qFQ==",
+      "requires": {
+        "color": "^3.0.0"
+      }
+    },
 		"color": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",

--- a/packages/bpk-foundations-web/package-lock.json
+++ b/packages/bpk-foundations-web/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "@skyscanner/bpk-foundations-web",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@skyscanner/bpk-foundations-common": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-1.0.0.tgz",
-			"integrity": "sha512-rH79IdIzoU0Bjwz4aWh59pThIDLhmfNs8k8JrtrWkGN/SZIyJx6sdFAW+JaQcAlWHLea1vxJHxOkT09zYS5qFQ==",
-			"requires": {
-				"color": "^3.0.0"
-			}
-		},
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-1.0.0.tgz",
+      "integrity": "sha512-rH79IdIzoU0Bjwz4aWh59pThIDLhmfNs8k8JrtrWkGN/SZIyJx6sdFAW+JaQcAlWHLea1vxJHxOkT09zYS5qFQ==",
+      "requires": {
+        "color": "^3.0.0"
+      }
+    },
 		"color": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",

--- a/packages/bpk-foundations-web/src/base/ratings.json
+++ b/packages/bpk-foundations-web/src/base/ratings.json
@@ -8,27 +8,34 @@
   "props": {
     "RATING_BASE_WIDTH" : {
       "value": "{!SPACING_SM} * 4",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
+
     },
     "RATING_BASE_HEIGHT" : {
       "value": "{!SPACING_SM} * 4",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "RATING_SM_WIDTH" : {
       "value": "{!SPACING_SM} * 3",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "RATING_SM_HEIGHT" : {
       "value": "{!SPACING_SM} * 3",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "RATING_LG_WIDTH" : {
       "value": "{!SPACING_LG} * 2",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "RATING_LG_HEIGHT" : {
       "value": "{!SPACING_LG} * 2",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     }
   }
 }

--- a/packages/bpk-foundations-web/tokens/base.raw.json
+++ b/packages/bpk-foundations-web/tokens/base.raw.json
@@ -2261,6 +2261,7 @@
       "category": "ratings",
       "value": ".75rem * 4",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_SM} * 4",
       "name": "RATING_BASE_WIDTH"
     },
@@ -2268,6 +2269,7 @@
       "category": "ratings",
       "value": ".75rem * 4",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_SM} * 4",
       "name": "RATING_BASE_HEIGHT"
     },
@@ -2275,6 +2277,7 @@
       "category": "ratings",
       "value": ".75rem * 3",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_SM} * 3",
       "name": "RATING_SM_WIDTH"
     },
@@ -2282,6 +2285,7 @@
       "category": "ratings",
       "value": ".75rem * 3",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_SM} * 3",
       "name": "RATING_SM_HEIGHT"
     },
@@ -2289,6 +2293,7 @@
       "category": "ratings",
       "value": "1.875rem * 2",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_LG} * 2",
       "name": "RATING_LG_WIDTH"
     },
@@ -2296,6 +2301,7 @@
       "category": "ratings",
       "value": "1.875rem * 2",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_LG} * 2",
       "name": "RATING_LG_HEIGHT"
     },


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

As part of the moving to the new spacing grid for the rating component https://github.com/Skyscanner/backpack/pull/2233, we are deprecating the rating tokens as they just served as an abstraction layer to just the rating component.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
