### PR TITLE
[KOA-4550]: Deprecate no longer used modal token

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Changed:**
+
+- @skyscanner/bpk-foundations-web:
+  - The `bpk-modal-header-padding` token is now deprecated. To migrate, use an equivalent spacing value.

--- a/packages/bpk-foundations-web/package-lock.json
+++ b/packages/bpk-foundations-web/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@skyscanner/bpk-foundations-web",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/bpk-foundations-web/src/base/modals.json
+++ b/packages/bpk-foundations-web/src/base/modals.json
@@ -28,7 +28,8 @@
     },
     "MODAL_HEADER_PADDING": {
       "value": "{!SPACING_SM}",
-      "type": "size"
+      "type": "size",
+      "deprecated": true
     },
     "MODAL_CONTENT_PADDING": {
       "value": "{!SPACING_SM}",

--- a/packages/bpk-foundations-web/tokens/base.raw.json
+++ b/packages/bpk-foundations-web/tokens/base.raw.json
@@ -2089,6 +2089,7 @@
       "category": "modals",
       "value": ".75rem",
       "type": "size",
+      "deprecated": true,
       "originalValue": "{!SPACING_SM}",
       "name": "MODAL_HEADER_PADDING"
     },


### PR DESCRIPTION
As part of changing the popover component to use the new spacing grid https://github.com/Skyscanner/backpack/pull/2247,  we are deprecating the modal header padding token as it is no longer used.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
