### PR TITLE
KOA-4830 Update text secondary dark colour

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Fixed:**
+
+- @skyscanner/bpk-foundations-android:
+  - Updated TEXT_SECONDARY_DARK_COLOR to SKY_GRAY_TINT_04

--- a/packages/bpk-foundations-android/src/base/typography.json
+++ b/packages/bpk-foundations-android/src/base/typography.json
@@ -42,7 +42,7 @@
       "category": "text-colors"
     },
     "TEXT_SECONDARY_DARK_COLOR": {
-      "value": "{!BLACK_TINT_06}",
+      "value": "{!SKY_GRAY_TINT_04}",
       "type": "color",
       "category": "text-colors"
     },

--- a/packages/bpk-foundations-android/tokens/base.android.xml
+++ b/packages/bpk-foundations-android/tokens/base.android.xml
@@ -142,7 +142,7 @@
   <color name="TEXT_PRIMARY_LIGHT_COLOR" category="text-colors">#ff111236</color>
   <color name="TEXT_QUATERNARY_DARK_COLOR" category="text-colors">#ff8e8e93</color>
   <color name="TEXT_QUATERNARY_LIGHT_COLOR" category="text-colors">#ff8f90a0</color>
-  <color name="TEXT_SECONDARY_DARK_COLOR" category="text-colors">#ff8e8e93</color>
+  <color name="TEXT_SECONDARY_DARK_COLOR" category="text-colors">#ffb2b2bf</color>
   <color name="TEXT_SECONDARY_LIGHT_COLOR" category="text-colors">#ff68697f</color>
   <property name="TEXT_SM_FONT_SIZE" category="font-sizes">14sp</property>
   <property name="TEXT_SM_FONT_WEIGHT" category="font-weights">400</property>

--- a/packages/bpk-foundations-android/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-android/tokens/base.raw.android.json
@@ -1112,10 +1112,10 @@
       "name": "TEXT_QUATERNARY_LIGHT_COLOR"
     },
     "TEXT_SECONDARY_DARK_COLOR": {
-      "value": "#8e8e93ff",
+      "value": "#b2b2bfff",
       "type": "color",
       "category": "text-colors",
-      "originalValue": "{!BLACK_TINT_06}",
+      "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "TEXT_SECONDARY_DARK_COLOR"
     },
     "TEXT_SECONDARY_LIGHT_COLOR": {
@@ -1323,8 +1323,8 @@
       "category": "text-colors",
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "TEXT_SECONDARY_COLOR",
-      "darkValue": "#8e8e93ff",
-      "originalDarkValue": "{!BLACK_TINT_06}"
+      "darkValue": "#b2b2bfff",
+      "originalDarkValue": "{!SKY_GRAY_TINT_04}"
     },
     "TEXT_TERTIARY_COLOR": {
       "value": "#8f90a0ff",


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Updated the text secondary dark colour from black tint 6 to sky gray tint 4 for better accessibility

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
