### PR TITLE
KOA-4905 Deprecate old text style tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
+# 2022-01-28
+
+**Added:**
+- @skyscanner/bpk-foundations-commons: 2.1.0 => 2.2.0
+  - Added new style tokens
+  - Updated line heights
+
+- @skyscanner/bpk-foundations-ios: 2.1.0 => 2.2.0
+  - Added new style tokens
+  - Updated line heights
+
+- @skyscanner/bpk-foundations-android: 3.1.1 => 3.2.0
+  - Added new style tokens
+  - Updated line heights
+
+**Fixed:**
+- @skyscanner/bpk-foundations-android: 3.1.1 => 3.2.0
+  - Remove unused xml token file to avoid confusion
+
 # 2022-01-27
+
 **Fixed:**
 - @skyscanner/bpk-foundations-android: 3.1.0 => 3.1.1
   - Included originalTag where needed in xml version for tokens

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,16 +1,10 @@
-**Added:**
-- @skyscanner/bpk-foundations-commons:
-  - Added new style tokens
-  - Updated line heights
+**Fixed:**
+
+- @skyscanner/bpk-foundations-common:
+  - Add deprecation flag to old typography style tokens for apps
 
 - @skyscanner/bpk-foundations-ios:
-  - Added new style tokens
-  - Updated line heights
+  - Add deprecation flag to old typography style tokens
 
 - @skyscanner/bpk-foundations-android:
-  - Added new style tokens
-  - Updated line heights
-
-**Fixed:**
-- @skyscanner/bpk-foundations-android:
-  - Remove unused xml token file to avoid confusion
+  - Add deprecation flag to old typography style tokens

--- a/packages/bpk-foundations-android/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-android/tokens/base.raw.android.json
@@ -939,6 +939,7 @@
       "value": "10",
       "type": "font-size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_CAPS}",
       "name": "FONT_SIZE_CAPS"
     },
@@ -1191,6 +1192,7 @@
       "value": "16",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_BASE}",
       "name": "TEXT_BASE-EMPHASIZED_FONT_SIZE"
     },
@@ -1198,6 +1200,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_BASE-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1205,6 +1208,7 @@
       "value": "20",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_BASE-TIGHT}",
       "name": "TEXT_BASE-EMPHASIZED_LINE_HEIGHT"
     },
@@ -1212,6 +1216,7 @@
       "value": "16",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_BASE}",
       "name": "TEXT_BASE_FONT_SIZE"
     },
@@ -1219,6 +1224,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_BASE_FONT_WEIGHT"
     },
@@ -1226,6 +1232,7 @@
       "value": "24",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_BASE}",
       "name": "TEXT_BASE_LINE_HEIGHT"
     },
@@ -1275,6 +1282,7 @@
       "value": "10",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_CAPS}",
       "name": "TEXT_CAPS-EMPHASIZED_FONT_SIZE"
     },
@@ -1282,6 +1290,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_CAPS-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1289,6 +1298,7 @@
       "value": "10",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_CAPS}",
       "name": "TEXT_CAPS_FONT_SIZE"
     },
@@ -1296,6 +1306,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_CAPS_FONT_WEIGHT"
     },
@@ -1632,6 +1643,7 @@
       "value": "20",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_LG}",
       "name": "TEXT_LG-EMPHASIZED_FONT_SIZE"
     },
@@ -1639,6 +1651,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_LG-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1646,6 +1659,7 @@
       "value": "24",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_LG-TIGHT}",
       "name": "TEXT_LG-EMPHASIZED_LINE_HEIGHT"
     },
@@ -1653,6 +1667,7 @@
       "value": "20",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_LG}",
       "name": "TEXT_LG_FONT_SIZE"
     },
@@ -1660,6 +1675,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_LG_FONT_WEIGHT"
     },
@@ -1667,6 +1683,7 @@
       "value": "28",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_LG}",
       "name": "TEXT_LG_LINE_HEIGHT"
     },
@@ -1716,6 +1733,7 @@
       "value": "14",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_SM}",
       "name": "TEXT_SM-EMPHASIZED_FONT_SIZE"
     },
@@ -1723,6 +1741,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_SM-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1730,6 +1749,7 @@
       "value": "20",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_SM}",
       "name": "TEXT_SM-EMPHASIZED_LINE_HEIGHT"
     },
@@ -1737,6 +1757,7 @@
       "value": "14",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_SM}",
       "name": "TEXT_SM_FONT_SIZE"
     },
@@ -1744,6 +1765,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_SM_FONT_WEIGHT"
     },
@@ -1751,6 +1773,7 @@
       "value": "20",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_SM}",
       "name": "TEXT_SM_LINE_HEIGHT"
     },
@@ -1793,6 +1816,7 @@
       "value": "24",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XL}",
       "name": "TEXT_XL-EMPHASIZED_FONT_SIZE"
     },
@@ -1800,6 +1824,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_XL-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1807,6 +1832,7 @@
       "value": "28",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XL-TIGHT}",
       "name": "TEXT_XL-EMPHASIZED_LINE_HEIGHT"
     },
@@ -1814,6 +1840,7 @@
       "value": "24",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XL}",
       "name": "TEXT_XL-HEAVY_FONT_SIZE"
     },
@@ -1821,6 +1848,7 @@
       "value": "900",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "TEXT_XL-HEAVY_FONT_WEIGHT"
     },
@@ -1828,6 +1856,7 @@
       "value": "24",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XL}",
       "name": "TEXT_XL_FONT_SIZE"
     },
@@ -1835,6 +1864,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_XL_FONT_WEIGHT"
     },
@@ -1842,6 +1872,7 @@
       "value": "32",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XL}",
       "name": "TEXT_XL_LINE_HEIGHT"
     },
@@ -1849,6 +1880,7 @@
       "value": "12",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XS}",
       "name": "TEXT_XS-EMPHASIZED_FONT_SIZE"
     },
@@ -1856,6 +1888,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_XS-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1863,6 +1896,7 @@
       "value": "16",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XS}",
       "name": "TEXT_XS-EMPHASIZED_LINE_HEIGHT"
     },
@@ -1870,6 +1904,7 @@
       "value": "12",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XS}",
       "name": "TEXT_XS_FONT_SIZE"
     },
@@ -1877,6 +1912,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_XS_FONT_WEIGHT"
     },
@@ -1884,6 +1920,7 @@
       "value": "16",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XS}",
       "name": "TEXT_XS_LINE_HEIGHT"
     },
@@ -1891,6 +1928,7 @@
       "value": "32",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXL}",
       "name": "TEXT_XXL-EMPHASIZED_FONT_SIZE"
     },
@@ -1898,6 +1936,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_XXL-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1905,6 +1944,7 @@
       "value": "40",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XXL}",
       "name": "TEXT_XXL-EMPHASIZED_LINE_HEIGHT"
     },
@@ -1912,6 +1952,7 @@
       "value": "32",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXL}",
       "name": "TEXT_XXL-HEAVY_FONT_SIZE"
     },
@@ -1919,6 +1960,7 @@
       "value": "900",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "TEXT_XXL-HEAVY_FONT_WEIGHT"
     },
@@ -1926,6 +1968,7 @@
       "value": "32",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXL}",
       "name": "TEXT_XXL_FONT_SIZE"
     },
@@ -1933,6 +1976,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_XXL_FONT_WEIGHT"
     },
@@ -1940,6 +1984,7 @@
       "value": "40",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXXL}",
       "name": "TEXT_XXXL-EMPHASIZED_FONT_SIZE"
     },
@@ -1947,6 +1992,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_XXXL-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1954,6 +2000,7 @@
       "value": "48",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XXXL}",
       "name": "TEXT_XXXL-EMPHASIZED_LINE_HEIGHT"
     },
@@ -1961,6 +2008,7 @@
       "value": "40",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXXL}",
       "name": "TEXT_XXXL-HEAVY_FONT_SIZE"
     },
@@ -1968,6 +2016,7 @@
       "value": "900",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "TEXT_XXXL-HEAVY_FONT_WEIGHT"
     },
@@ -1975,6 +2024,7 @@
       "value": "40",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXXL}",
       "name": "TEXT_XXXL_FONT_SIZE"
     },
@@ -1982,6 +2032,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_XXXL_FONT_WEIGHT"
     },

--- a/packages/bpk-foundations-common/app/legacy-typography.json
+++ b/packages/bpk-foundations-common/app/legacy-typography.json
@@ -8,257 +8,308 @@
     "FONT_SIZE_CAPS": {
       "value": "{!FONT_SIZE_CAPS}",
       "type": "font-size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_CAPS_FONT_SIZE": {
       "value": "{!FONT_SIZE_CAPS}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_CAPS_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOOK}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_CAPS-EMPHASIZED_FONT_SIZE": {
       "value": "{!FONT_SIZE_CAPS}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_CAPS-EMPHASIZED_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOLD}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_XS_FONT_SIZE": {
       "value": "{!FONT_SIZE_XS}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_XS_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XS}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_XS_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOOK}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_XS-EMPHASIZED_FONT_SIZE": {
       "value": "{!FONT_SIZE_XS}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_XS-EMPHASIZED_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XS}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_XS-EMPHASIZED_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOLD}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_SM_FONT_SIZE": {
       "value": "{!FONT_SIZE_SM}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_SM_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_SM}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_SM_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOOK}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_SM-EMPHASIZED_FONT_SIZE": {
       "value": "{!FONT_SIZE_SM}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_SM-EMPHASIZED_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_SM}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_SM-EMPHASIZED_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOLD}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_BASE_FONT_SIZE": {
       "value": "{!FONT_SIZE_BASE}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_BASE_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_BASE}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_BASE_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOOK}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_BASE-EMPHASIZED_FONT_SIZE": {
       "value": "{!FONT_SIZE_BASE}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_BASE-EMPHASIZED_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_BASE-TIGHT}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_BASE-EMPHASIZED_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOLD}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_LG_FONT_SIZE": {
       "value": "{!FONT_SIZE_LG}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_LG_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_LG}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_LG_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOOK}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_LG-EMPHASIZED_FONT_SIZE": {
       "value": "{!FONT_SIZE_LG}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_LG-EMPHASIZED_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_LG-TIGHT}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_LG-EMPHASIZED_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOLD}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_XL_FONT_SIZE": {
       "value": "{!FONT_SIZE_XL}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_XL_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XL}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_XL_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOOK}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_XL-EMPHASIZED_FONT_SIZE": {
       "value": "{!FONT_SIZE_XL}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_XL-EMPHASIZED_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XL-TIGHT}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_XL-EMPHASIZED_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOLD}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_XL-HEAVY_FONT_SIZE": {
       "value": "{!FONT_SIZE_XL}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_XL-HEAVY_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BLACK}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_XXL_FONT_SIZE": {
       "value": "{!FONT_SIZE_XXL}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_XXL_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOOK}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_XXL-EMPHASIZED_FONT_SIZE": {
       "value": "{!FONT_SIZE_XXL}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_XXL-EMPHASIZED_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XXL}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_XXL-EMPHASIZED_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOLD}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_XXL-HEAVY_FONT_SIZE": {
       "value": "{!FONT_SIZE_XXL}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_XXL-HEAVY_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BLACK}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_XXXL_FONT_SIZE": {
       "value": "{!FONT_SIZE_XXXL}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_XXXL_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOOK}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_XXXL-EMPHASIZED_FONT_SIZE": {
       "value": "{!FONT_SIZE_XXXL}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_XXXL-EMPHASIZED_LINE_HEIGHT": {
       "value": "{!LINE_HEIGHT_XXXL}",
       "type": "size",
-      "category": "typesettings"
+      "category": "typesettings",
+      "deprecated": true
     },
     "TEXT_XXXL-EMPHASIZED_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BOLD}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     },
     "TEXT_XXXL-HEAVY_FONT_SIZE": {
       "value": "{!FONT_SIZE_XXXL}",
       "type": "font-size",
-      "category": "font-sizes"
+      "category": "font-sizes",
+      "deprecated": true
     },
     "TEXT_XXXL-HEAVY_FONT_WEIGHT": {
       "value": "{!FONT_WEIGHT_BLACK}",
       "type": "string",
-      "category": "font-weights"
+      "category": "font-weights",
+      "deprecated": true
     }
   }
 }

--- a/packages/bpk-foundations-ios/tokens/base.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.ios.json
@@ -634,6 +634,7 @@
       "value": "10",
       "type": "font-size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_CAPS}",
       "name": "fontSizeCaps"
     },
@@ -1012,6 +1013,7 @@
       "value": "16",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_BASE}",
       "name": "textBaseEmphasizedFontSize"
     },
@@ -1019,6 +1021,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "textBaseEmphasizedFontWeight"
     },
@@ -1026,6 +1029,7 @@
       "value": "20",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_BASE-TIGHT}",
       "name": "textBaseEmphasizedLineHeight"
     },
@@ -1033,6 +1037,7 @@
       "value": "16",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_BASE}",
       "name": "textBaseFontSize"
     },
@@ -1040,6 +1045,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "textBaseFontWeight"
     },
@@ -1054,6 +1060,7 @@
       "value": "24",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_BASE}",
       "name": "textBaseLineHeight"
     },
@@ -1103,6 +1110,7 @@
       "value": "10",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_CAPS}",
       "name": "textCapsEmphasizedFontSize"
     },
@@ -1110,6 +1118,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "textCapsEmphasizedFontWeight"
     },
@@ -1117,6 +1126,7 @@
       "value": "10",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_CAPS}",
       "name": "textCapsFontSize"
     },
@@ -1124,6 +1134,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "textCapsFontWeight"
     },
@@ -1467,6 +1478,7 @@
       "value": "20",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_LG}",
       "name": "textLgEmphasizedFontSize"
     },
@@ -1474,6 +1486,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "textLgEmphasizedFontWeight"
     },
@@ -1481,6 +1494,7 @@
       "value": "24",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_LG-TIGHT}",
       "name": "textLgEmphasizedLineHeight"
     },
@@ -1488,6 +1502,7 @@
       "value": "20",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_LG}",
       "name": "textLgFontSize"
     },
@@ -1495,6 +1510,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "textLgFontWeight"
     },
@@ -1509,6 +1525,7 @@
       "value": "28",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_LG}",
       "name": "textLgLineHeight"
     },
@@ -1558,6 +1575,7 @@
       "value": "14",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_SM}",
       "name": "textSmEmphasizedFontSize"
     },
@@ -1565,6 +1583,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "textSmEmphasizedFontWeight"
     },
@@ -1572,6 +1591,7 @@
       "value": "20",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_SM}",
       "name": "textSmEmphasizedLineHeight"
     },
@@ -1579,6 +1599,7 @@
       "value": "14",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_SM}",
       "name": "textSmFontSize"
     },
@@ -1586,6 +1607,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "textSmFontWeight"
     },
@@ -1600,6 +1622,7 @@
       "value": "20",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_SM}",
       "name": "textSmLineHeight"
     },
@@ -1642,6 +1665,7 @@
       "value": "24",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XL}",
       "name": "textXlEmphasizedFontSize"
     },
@@ -1649,6 +1673,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "textXlEmphasizedFontWeight"
     },
@@ -1656,6 +1681,7 @@
       "value": "28",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XL-TIGHT}",
       "name": "textXlEmphasizedLineHeight"
     },
@@ -1663,6 +1689,7 @@
       "value": "24",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XL}",
       "name": "textXlHeavyFontSize"
     },
@@ -1670,6 +1697,7 @@
       "value": "900",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "textXlHeavyFontWeight"
     },
@@ -1677,6 +1705,7 @@
       "value": "24",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XL}",
       "name": "textXlFontSize"
     },
@@ -1684,6 +1713,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "textXlFontWeight"
     },
@@ -1698,6 +1728,7 @@
       "value": "32",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XL}",
       "name": "textXlLineHeight"
     },
@@ -1705,6 +1736,7 @@
       "value": "12",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XS}",
       "name": "textXsEmphasizedFontSize"
     },
@@ -1712,6 +1744,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "textXsEmphasizedFontWeight"
     },
@@ -1719,6 +1752,7 @@
       "value": "16",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XS}",
       "name": "textXsEmphasizedLineHeight"
     },
@@ -1726,6 +1760,7 @@
       "value": "12",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XS}",
       "name": "textXsFontSize"
     },
@@ -1733,6 +1768,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "textXsFontWeight"
     },
@@ -1747,6 +1783,7 @@
       "value": "16",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XS}",
       "name": "textXsLineHeight"
     },
@@ -1754,6 +1791,7 @@
       "value": "32",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXL}",
       "name": "textXxlEmphasizedFontSize"
     },
@@ -1761,6 +1799,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "textXxlEmphasizedFontWeight"
     },
@@ -1768,6 +1807,7 @@
       "value": "40",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XXL}",
       "name": "textXxlEmphasizedLineHeight"
     },
@@ -1775,6 +1815,7 @@
       "value": "32",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXL}",
       "name": "textXxlHeavyFontSize"
     },
@@ -1782,6 +1823,7 @@
       "value": "900",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "textXxlHeavyFontWeight"
     },
@@ -1789,6 +1831,7 @@
       "value": "32",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXL}",
       "name": "textXxlFontSize"
     },
@@ -1796,6 +1839,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "textXxlFontWeight"
     },
@@ -1810,6 +1854,7 @@
       "value": "40",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXXL}",
       "name": "textXxxlEmphasizedFontSize"
     },
@@ -1817,6 +1862,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "textXxxlEmphasizedFontWeight"
     },
@@ -1824,6 +1870,7 @@
       "value": "48",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XXXL}",
       "name": "textXxxlEmphasizedLineHeight"
     },
@@ -1831,6 +1878,7 @@
       "value": "40",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXXL}",
       "name": "textXxxlHeavyFontSize"
     },
@@ -1838,6 +1886,7 @@
       "value": "900",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "textXxxlHeavyFontWeight"
     },
@@ -1845,6 +1894,7 @@
       "value": "40",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXXL}",
       "name": "textXxxlFontSize"
     },
@@ -1852,6 +1902,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "textXxxlFontWeight"
     },

--- a/packages/bpk-foundations-ios/tokens/base.raw.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.raw.ios.json
@@ -939,6 +939,7 @@
       "value": "10",
       "type": "font-size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_CAPS}",
       "name": "FONT_SIZE_CAPS"
     },
@@ -1317,6 +1318,7 @@
       "value": "16",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_BASE}",
       "name": "TEXT_BASE-EMPHASIZED_FONT_SIZE"
     },
@@ -1324,6 +1326,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_BASE-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1331,6 +1334,7 @@
       "value": "20",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_BASE-TIGHT}",
       "name": "TEXT_BASE-EMPHASIZED_LINE_HEIGHT"
     },
@@ -1338,6 +1342,7 @@
       "value": "16",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_BASE}",
       "name": "TEXT_BASE_FONT_SIZE"
     },
@@ -1345,6 +1350,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_BASE_FONT_WEIGHT"
     },
@@ -1359,6 +1365,7 @@
       "value": "24",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_BASE}",
       "name": "TEXT_BASE_LINE_HEIGHT"
     },
@@ -1408,6 +1415,7 @@
       "value": "10",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_CAPS}",
       "name": "TEXT_CAPS-EMPHASIZED_FONT_SIZE"
     },
@@ -1415,6 +1423,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_CAPS-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1422,6 +1431,7 @@
       "value": "10",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_CAPS}",
       "name": "TEXT_CAPS_FONT_SIZE"
     },
@@ -1429,6 +1439,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_CAPS_FONT_WEIGHT"
     },
@@ -1772,6 +1783,7 @@
       "value": "20",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_LG}",
       "name": "TEXT_LG-EMPHASIZED_FONT_SIZE"
     },
@@ -1779,6 +1791,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_LG-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1786,6 +1799,7 @@
       "value": "24",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_LG-TIGHT}",
       "name": "TEXT_LG-EMPHASIZED_LINE_HEIGHT"
     },
@@ -1793,6 +1807,7 @@
       "value": "20",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_LG}",
       "name": "TEXT_LG_FONT_SIZE"
     },
@@ -1800,6 +1815,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_LG_FONT_WEIGHT"
     },
@@ -1814,6 +1830,7 @@
       "value": "28",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_LG}",
       "name": "TEXT_LG_LINE_HEIGHT"
     },
@@ -1863,6 +1880,7 @@
       "value": "14",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_SM}",
       "name": "TEXT_SM-EMPHASIZED_FONT_SIZE"
     },
@@ -1870,6 +1888,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_SM-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1877,6 +1896,7 @@
       "value": "20",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_SM}",
       "name": "TEXT_SM-EMPHASIZED_LINE_HEIGHT"
     },
@@ -1884,6 +1904,7 @@
       "value": "14",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_SM}",
       "name": "TEXT_SM_FONT_SIZE"
     },
@@ -1891,6 +1912,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_SM_FONT_WEIGHT"
     },
@@ -1905,6 +1927,7 @@
       "value": "20",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_SM}",
       "name": "TEXT_SM_LINE_HEIGHT"
     },
@@ -1947,6 +1970,7 @@
       "value": "24",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XL}",
       "name": "TEXT_XL-EMPHASIZED_FONT_SIZE"
     },
@@ -1954,6 +1978,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_XL-EMPHASIZED_FONT_WEIGHT"
     },
@@ -1961,6 +1986,7 @@
       "value": "28",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XL-TIGHT}",
       "name": "TEXT_XL-EMPHASIZED_LINE_HEIGHT"
     },
@@ -1968,6 +1994,7 @@
       "value": "24",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XL}",
       "name": "TEXT_XL-HEAVY_FONT_SIZE"
     },
@@ -1975,6 +2002,7 @@
       "value": "900",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "TEXT_XL-HEAVY_FONT_WEIGHT"
     },
@@ -1982,6 +2010,7 @@
       "value": "24",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XL}",
       "name": "TEXT_XL_FONT_SIZE"
     },
@@ -1989,6 +2018,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_XL_FONT_WEIGHT"
     },
@@ -2003,6 +2033,7 @@
       "value": "32",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XL}",
       "name": "TEXT_XL_LINE_HEIGHT"
     },
@@ -2010,6 +2041,7 @@
       "value": "12",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XS}",
       "name": "TEXT_XS-EMPHASIZED_FONT_SIZE"
     },
@@ -2017,6 +2049,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_XS-EMPHASIZED_FONT_WEIGHT"
     },
@@ -2024,6 +2057,7 @@
       "value": "16",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XS}",
       "name": "TEXT_XS-EMPHASIZED_LINE_HEIGHT"
     },
@@ -2031,6 +2065,7 @@
       "value": "12",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XS}",
       "name": "TEXT_XS_FONT_SIZE"
     },
@@ -2038,6 +2073,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_XS_FONT_WEIGHT"
     },
@@ -2052,6 +2088,7 @@
       "value": "16",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XS}",
       "name": "TEXT_XS_LINE_HEIGHT"
     },
@@ -2059,6 +2096,7 @@
       "value": "32",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXL}",
       "name": "TEXT_XXL-EMPHASIZED_FONT_SIZE"
     },
@@ -2066,6 +2104,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_XXL-EMPHASIZED_FONT_WEIGHT"
     },
@@ -2073,6 +2112,7 @@
       "value": "40",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XXL}",
       "name": "TEXT_XXL-EMPHASIZED_LINE_HEIGHT"
     },
@@ -2080,6 +2120,7 @@
       "value": "32",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXL}",
       "name": "TEXT_XXL-HEAVY_FONT_SIZE"
     },
@@ -2087,6 +2128,7 @@
       "value": "900",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "TEXT_XXL-HEAVY_FONT_WEIGHT"
     },
@@ -2094,6 +2136,7 @@
       "value": "32",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXL}",
       "name": "TEXT_XXL_FONT_SIZE"
     },
@@ -2101,6 +2144,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_XXL_FONT_WEIGHT"
     },
@@ -2115,6 +2159,7 @@
       "value": "40",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXXL}",
       "name": "TEXT_XXXL-EMPHASIZED_FONT_SIZE"
     },
@@ -2122,6 +2167,7 @@
       "value": "700",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOLD}",
       "name": "TEXT_XXXL-EMPHASIZED_FONT_WEIGHT"
     },
@@ -2129,6 +2175,7 @@
       "value": "48",
       "type": "size",
       "category": "typesettings",
+      "deprecated": true,
       "originalValue": "{!LINE_HEIGHT_XXXL}",
       "name": "TEXT_XXXL-EMPHASIZED_LINE_HEIGHT"
     },
@@ -2136,6 +2183,7 @@
       "value": "40",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXXL}",
       "name": "TEXT_XXXL-HEAVY_FONT_SIZE"
     },
@@ -2143,6 +2191,7 @@
       "value": "900",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "TEXT_XXXL-HEAVY_FONT_WEIGHT"
     },
@@ -2150,6 +2199,7 @@
       "value": "40",
       "type": "font-size",
       "category": "font-sizes",
+      "deprecated": true,
       "originalValue": "{!FONT_SIZE_XXXL}",
       "name": "TEXT_XXXL_FONT_SIZE"
     },
@@ -2157,6 +2207,7 @@
       "value": "400",
       "type": "string",
       "category": "font-weights",
+      "deprecated": true,
       "originalValue": "{!FONT_WEIGHT_BOOK}",
       "name": "TEXT_XXXL_FONT_WEIGHT"
     },


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->
These should no longer be used in favour of the new typography system. We want to be able to differentiate between the styles on the app side

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
