### PR TITLE
[KOA-4903]: Enable google analytics in sassdoc

### DIFF
--- a/.sassdocrc
+++ b/.sassdocrc
@@ -1,0 +1,4 @@
+dest: dist-sassdoc
+googleAnalytics: UA-246109-143
+strict: true
+verbose: true

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "preinstall": "npx ensure-node-env",
     "prettier": "prettier --config .prettierrc --write \"**/*.{js,jsx}\"",
     "release": "lerna bootstrap && npm run build && npm test && lerna publish",
-    "sassdoc": "sassdoc {packages/bpk-mixins/src/**/*,packages/bpk-svgs/dist/*,packages/bpk-foundations-web/tokens/base.default}.scss -d dist-sassdoc -v --strict",
+    "sassdoc": "sassdoc {packages/bpk-mixins/src/**/*,packages/bpk-svgs/dist/*,packages/bpk-foundations-web/tokens/base.default}.scss",
     "test": "npm run lint && npm run jest && npm run flow"
   },
   "jest": {


### PR DESCRIPTION
Enabling Google Analytics in Sassdoc and moving the Sassdoc config into its own file