### PR TITLE
[KOA-5021]: Typography mixins to remain the same size on all screens

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Breaking:**
+
+- bpk-mixins:
+  - Removed differing `typography` styles that were applied when on mobile devices to keep the same style as when on desktop.

--- a/packages/bpk-mixins/src/mixins/_typography.scss
+++ b/packages/bpk-mixins/src/mixins/_typography.scss
@@ -588,14 +588,6 @@ $bpk-spacing-v2: true;
     $bpk-line-height-xxxl,
     $bpk-font-weight-bold
   );
-
-  @include bpk-breakpoint-mobile {
-    @include _bpk-text-factory(
-      $bpk-font-size-xxl,
-      $bpk-line-height-xxl,
-      $bpk-font-weight-bold
-    );
-  }
 }
 
 /// Level 2 heading.
@@ -611,14 +603,6 @@ $bpk-spacing-v2: true;
     $bpk-line-height-xxl,
     $bpk-font-weight-bold
   );
-
-  @include bpk-breakpoint-mobile {
-    @include _bpk-text-factory(
-      $bpk-font-size-xl,
-      $bpk-line-height-xl-tight,
-      $bpk-font-weight-bold
-    );
-  }
 }
 
 /// Level 3 heading.
@@ -634,14 +618,6 @@ $bpk-spacing-v2: true;
     $bpk-line-height-xl-tight,
     $bpk-font-weight-bold
   );
-
-  @include bpk-breakpoint-mobile {
-    @include _bpk-text-factory(
-      $bpk-font-size-lg,
-      $bpk-line-height-lg-tight,
-      $bpk-font-weight-bold
-    );
-  }
 }
 
 /// Level 4 heading.
@@ -657,14 +633,6 @@ $bpk-spacing-v2: true;
     $bpk-line-height-lg-tight,
     $bpk-font-weight-bold
   );
-
-  @include bpk-breakpoint-mobile {
-    @include _bpk-text-factory(
-      $bpk-font-size-base,
-      $bpk-line-height-base-tight,
-      $bpk-font-weight-bold
-    );
-  }
 }
 
 /// Level 5 heading.
@@ -1162,10 +1130,6 @@ $bpk-spacing-v2: true;
     margin-bottom: $bpk-spacing-sm;
 
     @include bpk-text-xxxxl;
-
-    @include bpk-breakpoint-mobile {
-      @include bpk-text-xxl;
-    }
   }
 
   h2 {
@@ -1174,10 +1138,6 @@ $bpk-spacing-v2: true;
     margin-bottom: $bpk-spacing-sm;
 
     @include bpk-text-xxl;
-
-    @include bpk-breakpoint-mobile {
-      @include bpk-text-xl;
-    }
   }
 
   h3 {
@@ -1186,11 +1146,6 @@ $bpk-spacing-v2: true;
     margin-bottom: $bpk-spacing-sm;
 
     @include bpk-text-xl;
-
-    @include bpk-breakpoint-mobile {
-      @include bpk-text-base;
-      @include bpk-text-bold;
-    }
   }
 
   h4 {
@@ -1199,11 +1154,6 @@ $bpk-spacing-v2: true;
     margin-bottom: $bpk-spacing-xs;
 
     @include bpk-text-base;
-
-    @include bpk-breakpoint-mobile {
-      @include bpk-text-xs;
-      @include bpk-text-bold;
-    }
   }
 
   h5 {
@@ -1212,11 +1162,6 @@ $bpk-spacing-v2: true;
     margin-bottom: $bpk-spacing-sm;
 
     @include bpk-text-xs;
-
-    @include bpk-breakpoint-mobile {
-      @include bpk-text-xs;
-      @include bpk-text-bold;
-    }
   }
 
   h6 {
@@ -1225,11 +1170,6 @@ $bpk-spacing-v2: true;
     margin-bottom: $bpk-spacing-sm;
 
     @include bpk-text-xs;
-
-    @include bpk-breakpoint-mobile {
-      @include bpk-text-xs;
-      @include bpk-text-bold;
-    }
   }
 
   a {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Updated typography mixins to keep the same size across all breakpoints instead of changing them based on device

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [x] `README.md`
- [x] Tests
- [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
