### PR TITLE
[BD-6222] Add strong badge theme to bpk-mixins

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Changed**
+
+- `bpk-mixins`
+    - The `strong` badge theme has been added, which aligns to our mobile implementations and meets the needs of users.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,4 +1,4 @@
 **Added**
 
 - `bpk-mixins`
-    - The `strong` badge theme has been added, which aligns to IOS and Android implementations and meets the needs of users.
+    - The `strong` badge theme has been added, which aligns to our APP implementations and better meets the needs of users.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,4 +1,4 @@
-**Changed**
+**Added**
 
 - `bpk-mixins`
-    - The `strong` badge theme has been added, which aligns to our mobile implementations and meets the needs of users.
+    - The `strong` badge theme has been added, which aligns to IOS and Android implementations and meets the needs of users.

--- a/packages/bpk-mixins/src/mixins/_badges.scss
+++ b/packages/bpk-mixins/src/mixins/_badges.scss
@@ -204,3 +204,19 @@
   box-shadow: inset 0 0 0 $bpk-border-size-sm $bpk-color-white;
   fill: $bpk-color-white;
 }
+
+/// Strong badge. Modifies the bpk-badge mixin.
+///
+/// @require {mixin} bpk-badge
+///
+/// @example scss
+///   .selector {
+///     @include bpk-badge();
+///     @include bpk-badge--strong();
+///   }
+
+@mixin bpk-badge--strong {
+  background-color: $bpk-color-sky-blue-shade-03;
+  color: $bpk-color-white;
+  fill: $bpk-color-white;
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->
Figma: https://www.figma.com/file/irZ3YBx8vOm16ICkAr7mB3/Backpack?node-id=6099%3A2722

In the new design of the hotel card, we have made extensive use of `BpkBadge` which is white color on a black background.
But this theme style is not yet well supported on the web (they are already supported on iOs and Android).
So we added it to `bpk-component-badge` as the base theme - **strong**, for better consistency support and user experience.

Related PR in backpack: https://github.com/Skyscanner/backpack/pull/2532

## Snapshot
![image](https://user-images.githubusercontent.com/86780745/184083314-a3092525-4341-41a9-8aa6-db71ae03d7e5.png)

![image](https://user-images.githubusercontent.com/86780745/184083255-8d329407-3835-4996-b303-0384c6ea6f8c.png)
Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
