### PR TITLE
[KOA-5517]: Deprecate old colour tokens

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,8 @@
+**Changed:**
+
+`@skyscanner/bpk-foundations-common`<br />
+`@skyscanner/bpk-foundations-android`<br />
+`@skyscanner/bpk-foundations-ios`<br />
+`@skyscanner/bpk-foundations-react-native`<br />
+`@skyscanner/bpk-foundations-web` <br />
+  - Deprecated all the old colour tokens from the old colour system in prepareation for the new colours. You will see warning in code mentioning these have been deprecated but further comms to swap to, to follow.

--- a/packages/bpk-foundations-android/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-android/tokens/base.raw.android.json
@@ -420,6 +420,7 @@
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_ALTERNATIVE_DARK_COLOR"
     },
@@ -427,6 +428,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_ALTERNATIVE_LIGHT_COLOR"
     },
@@ -434,6 +436,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_DARK_COLOR"
     },
@@ -441,6 +444,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_LIGHT_COLOR"
     },
@@ -448,6 +452,7 @@
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_DARK_COLOR"
     },
@@ -455,6 +460,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ELEVATION_01_DARK_COLOR"
     },
@@ -462,6 +468,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_01_LIGHT_COLOR"
     },
@@ -469,6 +476,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_ELEVATION_02_DARK_COLOR"
     },
@@ -476,6 +484,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_02_LIGHT_COLOR"
     },
@@ -483,6 +492,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "BACKGROUND_ELEVATION_03_DARK_COLOR"
     },
@@ -490,6 +500,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_03_LIGHT_COLOR"
     },
@@ -497,6 +508,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_LIGHT_COLOR"
     },
@@ -504,6 +516,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_SECONDARY_DARK_COLOR"
     },
@@ -511,6 +524,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_SECONDARY_LIGHT_COLOR"
     },
@@ -518,6 +532,7 @@
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_TERTIARY_DARK_COLOR"
     },
@@ -525,6 +540,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_TERTIARY_LIGHT_COLOR"
     },
@@ -672,6 +688,7 @@
       "type": "color",
       "category": "colors",
       "value": "#5a489bff",
+      "deprecated": true,
       "originalValue": "{!ABISKO}",
       "name": "COLOR_ABISKO"
     },
@@ -679,6 +696,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffebd0ff",
+      "deprecated": true,
       "originalValue": "{!BAGAN}",
       "name": "COLOR_BAGAN"
     },
@@ -693,6 +711,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "COLOR_BLACK_TINT_01"
     },
@@ -700,6 +719,7 @@
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "COLOR_BLACK_TINT_02"
     },
@@ -707,6 +727,7 @@
       "type": "color",
       "category": "colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "COLOR_BLACK_TINT_03"
     },
@@ -714,6 +735,7 @@
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "COLOR_BLACK_TINT_04"
     },
@@ -721,6 +743,7 @@
       "type": "color",
       "category": "colors",
       "value": "#636366ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_05}",
       "name": "COLOR_BLACK_TINT_05"
     },
@@ -728,6 +751,7 @@
       "type": "color",
       "category": "colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "COLOR_BLACK_TINT_06"
     },
@@ -735,6 +759,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ff7b59ff",
+      "deprecated": true,
       "originalValue": "{!BUNOL}",
       "name": "COLOR_BUNOL"
     },
@@ -742,6 +767,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffb54dff",
+      "deprecated": true,
       "originalValue": "{!ERFOUD}",
       "name": "COLOR_ERFOUD"
     },
@@ -749,6 +775,7 @@
       "type": "color",
       "category": "colors",
       "value": "#73cec6ff",
+      "deprecated": true,
       "originalValue": "{!GLENCOE}",
       "name": "COLOR_GLENCOE"
     },
@@ -756,6 +783,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f6dde1ff",
+      "deprecated": true,
       "originalValue": "{!HARBOUR}",
       "name": "COLOR_HARBOUR"
     },
@@ -763,6 +791,7 @@
       "type": "color",
       "category": "colors",
       "value": "#e18b96ff",
+      "deprecated": true,
       "originalValue": "{!HILLIER}",
       "name": "COLOR_HILLIER"
     },
@@ -770,6 +799,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ff9400ff",
+      "deprecated": true,
       "originalValue": "{!KOLKATA}",
       "name": "COLOR_KOLKATA"
     },
@@ -777,6 +807,7 @@
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_MONTEVERDE"
     },
@@ -784,6 +815,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffe7e0ff",
+      "deprecated": true,
       "originalValue": "{!NARA}",
       "name": "COLOR_NARA"
     },
@@ -791,6 +823,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_PANJIN"
     },
@@ -798,6 +831,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffab95ff",
+      "deprecated": true,
       "originalValue": "{!PETRA}",
       "name": "COLOR_PETRA"
     },
@@ -805,6 +839,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "COLOR_PRIMARY_GRADIENT_LIGHT"
     },
@@ -812,6 +847,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d0eeecff",
+      "deprecated": true,
       "originalValue": "{!SAGANO}",
       "name": "COLOR_SAGANO"
     },
@@ -826,6 +862,7 @@
       "type": "color",
       "category": "colors",
       "value": "#084eb2ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_01}",
       "name": "COLOR_SKY_BLUE_SHADE_01"
     },
@@ -833,6 +870,7 @@
       "type": "color",
       "category": "colors",
       "value": "#042759ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_02}",
       "name": "COLOR_SKY_BLUE_SHADE_02"
     },
@@ -840,6 +878,7 @@
       "type": "color",
       "category": "colors",
       "value": "#02122cff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_03}",
       "name": "COLOR_SKY_BLUE_SHADE_03"
     },
@@ -847,6 +886,7 @@
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "COLOR_SKY_BLUE_TINT_01"
     },
@@ -854,6 +894,7 @@
       "type": "color",
       "category": "colors",
       "value": "#9dc0f2ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_02}",
       "name": "COLOR_SKY_BLUE_TINT_02"
     },
@@ -861,6 +902,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cddff8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_03}",
       "name": "COLOR_SKY_BLUE_TINT_03"
     },
@@ -868,6 +910,7 @@
       "type": "color",
       "category": "colors",
       "value": "#111236ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "COLOR_SKY_GRAY"
     },
@@ -875,6 +918,7 @@
       "type": "color",
       "category": "colors",
       "value": "#444560ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_01}",
       "name": "COLOR_SKY_GRAY_TINT_01"
     },
@@ -882,6 +926,7 @@
       "type": "color",
       "category": "colors",
       "value": "#68697fff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "COLOR_SKY_GRAY_TINT_02"
     },
@@ -889,6 +934,7 @@
       "type": "color",
       "category": "colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "COLOR_SKY_GRAY_TINT_03"
     },
@@ -896,6 +942,7 @@
       "type": "color",
       "category": "colors",
       "value": "#b2b2bfff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "COLOR_SKY_GRAY_TINT_04"
     },
@@ -903,6 +950,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "COLOR_SKY_GRAY_TINT_05"
     },
@@ -910,6 +958,7 @@
       "type": "color",
       "category": "colors",
       "value": "#dddde5ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_06}",
       "name": "COLOR_SKY_GRAY_TINT_06"
     },
@@ -917,6 +966,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "COLOR_SKY_GRAY_TINT_07"
     },
@@ -924,6 +974,7 @@
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_SYSTEM_GREEN"
     },
@@ -931,6 +982,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_SYSTEM_RED"
     },
@@ -938,6 +990,7 @@
       "type": "color",
       "category": "colors",
       "value": "#e1ddecff",
+      "deprecated": true,
       "originalValue": "{!TOCHIGI}",
       "name": "COLOR_TOCHIGI"
     },
@@ -945,6 +998,7 @@
       "type": "color",
       "category": "colors",
       "value": "#a59bc8ff",
+      "deprecated": true,
       "originalValue": "{!VALENSOLE}",
       "name": "COLOR_VALENSOLE"
     },
@@ -1163,6 +1217,7 @@
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "LINE_DARK_COLOR"
     },
@@ -1282,6 +1337,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "LINE_LIGHT_COLOR"
     },
@@ -1415,6 +1471,7 @@
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "PRIMARY_DARK_COLOR"
     },
@@ -1422,6 +1479,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_LIGHT_COLOR"
     },
@@ -2229,6 +2287,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "TEXT_PRIMARY_DARK_COLOR"
     },
@@ -2257,6 +2316,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#111236ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "TEXT_PRIMARY_LIGHT_COLOR"
     },
@@ -2271,6 +2331,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_QUATERNARY_DARK_COLOR"
     },
@@ -2278,6 +2339,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_QUATERNARY_LIGHT_COLOR"
     },
@@ -2285,6 +2347,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#b2b2bfff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "TEXT_SECONDARY_DARK_COLOR"
     },
@@ -2299,6 +2362,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#68697fff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "TEXT_SECONDARY_LIGHT_COLOR"
     },
@@ -2383,6 +2447,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_TERTIARY_DARK_COLOR"
     },
@@ -2390,6 +2455,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_TERTIARY_LIGHT_COLOR"
     },
@@ -2621,6 +2687,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_ALTERNATIVE_COLOR",
       "darkValue": "#000000ff",
@@ -2630,6 +2697,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_COLOR",
       "darkValue": "#1d1b20ff",
@@ -2639,6 +2707,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_COLOR",
       "darkValue": "#000000ff",
@@ -2648,6 +2717,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_01_COLOR",
       "darkValue": "#1d1b20ff",
@@ -2657,6 +2727,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_02_COLOR",
       "darkValue": "#2c2c2eff",
@@ -2666,6 +2737,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_03_COLOR",
       "darkValue": "#3a3a3cff",
@@ -2675,6 +2747,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_SECONDARY_COLOR",
       "darkValue": "#1d1b20ff",
@@ -2684,6 +2757,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_TERTIARY_COLOR",
       "darkValue": "#2c2c2eff",
@@ -2738,6 +2812,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "LINE_COLOR",
       "darkValue": "#48484aff",
@@ -2747,6 +2822,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_COLOR",
       "darkValue": "#6d9febff",
@@ -2900,6 +2976,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#111236ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "TEXT_PRIMARY_COLOR",
       "darkValue": "#ffffffff",
@@ -2918,6 +2995,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_QUATERNARY_COLOR",
       "darkValue": "#8e8e93ff",
@@ -2927,6 +3005,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#68697fff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "TEXT_SECONDARY_COLOR",
       "darkValue": "#b2b2bfff",
@@ -2936,6 +3015,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_TERTIARY_COLOR",
       "darkValue": "#8e8e93ff",

--- a/packages/bpk-foundations-common/base/colors/base.json
+++ b/packages/bpk-foundations-common/base/colors/base.json
@@ -12,115 +12,151 @@
       "value": "{!SKY_BLUE}"
     },
     "COLOR_MONTEVERDE": {
-      "value": "{!MONTEVERDE}"
+      "value": "{!MONTEVERDE}",
+      "deprecated": true
     },
     "COLOR_GLENCOE": {
-      "value": "{!GLENCOE}"
+      "value": "{!GLENCOE}",
+      "deprecated": true
     },
     "COLOR_SAGANO": {
-      "value": "{!SAGANO}"
+      "value": "{!SAGANO}",
+      "deprecated": true
     },
     "COLOR_KOLKATA": {
-      "value": "{!KOLKATA}"
+      "value": "{!KOLKATA}",
+      "deprecated": true
     },
     "COLOR_ERFOUD": {
-      "value": "{!ERFOUD}"
+      "value": "{!ERFOUD}",
+      "deprecated": true
     },
     "COLOR_BAGAN": {
-      "value": "{!BAGAN}"
+      "value": "{!BAGAN}",
+      "deprecated": true
     },
     "COLOR_BUNOL": {
-      "value": "{!BUNOL}"
+      "value": "{!BUNOL}",
+      "deprecated": true
     },
     "COLOR_PETRA": {
-      "value": "{!PETRA}"
+      "value": "{!PETRA}",
+      "deprecated": true
     },
     "COLOR_NARA": {
-      "value": "{!NARA}"
+      "value": "{!NARA}",
+      "deprecated": true
     },
     "COLOR_ABISKO": {
-      "value": "{!ABISKO}"
+      "value": "{!ABISKO}",
+      "deprecated": true
     },
     "COLOR_VALENSOLE": {
-      "value": "{!VALENSOLE}"
+      "value": "{!VALENSOLE}",
+      "deprecated": true
     },
     "COLOR_TOCHIGI": {
-      "value": "{!TOCHIGI}"
+      "value": "{!TOCHIGI}",
+      "deprecated": true
     },
     "COLOR_PANJIN": {
-      "value": "{!PANJIN}"
+      "value": "{!PANJIN}",
+      "deprecated": true
     },
     "COLOR_HILLIER": {
-      "value": "{!HILLIER}"
+      "value": "{!HILLIER}",
+      "deprecated": true
     },
     "COLOR_HARBOUR": {
-      "value": "{!HARBOUR}"
+      "value": "{!HARBOUR}",
+      "deprecated": true
     },
     "COLOR_SKY_BLUE_SHADE_03": {
-      "value": "{!SKY_BLUE_SHADE_03}"
+      "value": "{!SKY_BLUE_SHADE_03}",
+      "deprecated": true
     },
     "COLOR_SKY_BLUE_SHADE_02": {
-      "value": "{!SKY_BLUE_SHADE_02}"
+      "value": "{!SKY_BLUE_SHADE_02}",
+      "deprecated": true
     },
     "COLOR_SKY_BLUE_SHADE_01": {
-      "value": "{!SKY_BLUE_SHADE_01}"
+      "value": "{!SKY_BLUE_SHADE_01}",
+      "deprecated": true
     },
     "COLOR_SKY_BLUE_TINT_01": {
-      "value": "{!SKY_BLUE_TINT_01}"
+      "value": "{!SKY_BLUE_TINT_01}",
+      "deprecated": true
     },
     "COLOR_SKY_BLUE_TINT_02": {
-      "value": "{!SKY_BLUE_TINT_02}"
+      "value": "{!SKY_BLUE_TINT_02}",
+      "deprecated": true
     },
     "COLOR_SKY_BLUE_TINT_03": {
-      "value": "{!SKY_BLUE_TINT_03}"
+      "value": "{!SKY_BLUE_TINT_03}",
+      "deprecated": true
     },
     "COLOR_SKY_GRAY_TINT_07": {
-      "value": "{!SKY_GRAY_TINT_07}"
+      "value": "{!SKY_GRAY_TINT_07}",
+      "deprecated": true
     },
     "COLOR_SKY_GRAY_TINT_06": {
-      "value": "{!SKY_GRAY_TINT_06}"
+      "value": "{!SKY_GRAY_TINT_06}",
+      "deprecated": true
     },
     "COLOR_SKY_GRAY_TINT_05": {
-      "value": "{!SKY_GRAY_TINT_05}"
+      "value": "{!SKY_GRAY_TINT_05}",
+      "deprecated": true
     },
     "COLOR_SKY_GRAY_TINT_04": {
-      "value": "{!SKY_GRAY_TINT_04}"
+      "value": "{!SKY_GRAY_TINT_04}",
+      "deprecated": true
     },
     "COLOR_SKY_GRAY_TINT_03": {
-      "value": "{!SKY_GRAY_TINT_03}"
+      "value": "{!SKY_GRAY_TINT_03}",
+      "deprecated": true
     },
     "COLOR_SKY_GRAY_TINT_02": {
-      "value": "{!SKY_GRAY_TINT_02}"
+      "value": "{!SKY_GRAY_TINT_02}",
+      "deprecated": true
     },
     "COLOR_SKY_GRAY_TINT_01": {
-      "value": "{!SKY_GRAY_TINT_01}"
+      "value": "{!SKY_GRAY_TINT_01}",
+      "deprecated": true
     },
     "COLOR_SKY_GRAY": {
-      "value": "{!SKY_GRAY}"
+      "value": "{!SKY_GRAY}",
+      "deprecated": true
     },
     "COLOR_PRIMARY_GRADIENT_LIGHT": {
-      "value": "{!SKY_BLUE}"
+      "value": "{!SKY_BLUE}",
+      "deprecated": true
     },
     "COLOR_BLACK": {
       "value": "{!BLACK}"
     },
     "COLOR_BLACK_TINT_01": {
-      "value": "{!BLACK_TINT_01}"
+      "value": "{!BLACK_TINT_01}",
+      "deprecated": true
     },
     "COLOR_BLACK_TINT_02": {
-      "value": "{!BLACK_TINT_02}"
+      "value": "{!BLACK_TINT_02}",
+      "deprecated": true
     },
     "COLOR_BLACK_TINT_03": {
-      "value": "{!BLACK_TINT_03}"
+      "value": "{!BLACK_TINT_03}",
+      "deprecated": true
     },
     "COLOR_BLACK_TINT_04": {
-      "value": "{!BLACK_TINT_04}"
+      "value": "{!BLACK_TINT_04}",
+      "deprecated": true
     },
     "COLOR_BLACK_TINT_05": {
-      "value": "{!BLACK_TINT_05}"
+      "value": "{!BLACK_TINT_05}",
+      "deprecated": true
     },
     "COLOR_BLACK_TINT_06": {
-      "value": "{!BLACK_TINT_06}"
+      "value": "{!BLACK_TINT_06}",
+      "deprecated": true
     }
   }
 }

--- a/packages/bpk-foundations-common/base/colors/other.json
+++ b/packages/bpk-foundations-common/base/colors/other.json
@@ -4,22 +4,26 @@
     "COLOR_SYSTEM_RED": {
       "type": "color",
       "category": "colors",
-      "value": "{!PANJIN}"
+      "value": "{!PANJIN}",
+      "deprecated": true
     },
     "COLOR_SYSTEM_GREEN": {
       "type": "color",
       "category": "colors",
-      "value": "{!MONTEVERDE}"
+      "value": "{!MONTEVERDE}",
+      "deprecated": true
     },
     "LINE_LIGHT_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!SKY_GRAY_TINT_05}"
+      "value": "{!SKY_GRAY_TINT_05}",
+      "deprecated": true
     },
     "LINE_DARK_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!BLACK_TINT_04}"
+      "value": "{!BLACK_TINT_04}",
+      "deprecated": true
     },
     "LINE_DAY": {
       "type": "color",
@@ -44,92 +48,110 @@
     "PRIMARY_LIGHT_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!SKY_BLUE}"
+      "value": "{!SKY_BLUE}",
+      "deprecated": true
     },
     "PRIMARY_DARK_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!SKY_BLUE_TINT_01}"
+      "value": "{!SKY_BLUE_TINT_01}",
+      "deprecated": true
     },
     "BACKGROUND_LIGHT_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!WHITE}"
+      "value": "{!WHITE}",
+      "deprecated": true
     },
     "BACKGROUND_DARK_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!BLACK}"
+      "value": "{!BLACK}",
+      "deprecated": true
     },
     "BACKGROUND_ALTERNATIVE_LIGHT_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!SKY_GRAY_TINT_07}"
+      "value": "{!SKY_GRAY_TINT_07}",
+      "deprecated": true
     },
     "BACKGROUND_ALTERNATIVE_DARK_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!BLACK}"
+      "value": "{!BLACK}",
+      "deprecated": true
     },
     "BACKGROUND_SECONDARY_LIGHT_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!SKY_GRAY_TINT_07}"
+      "value": "{!SKY_GRAY_TINT_07}",
+      "deprecated": true
     },
     "BACKGROUND_SECONDARY_DARK_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!BLACK_TINT_01}"
+      "value": "{!BLACK_TINT_01}",
+      "deprecated": true
     },
     "BACKGROUND_ALTERNATIVE_SECONDARY_LIGHT_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!WHITE}"
+      "value": "{!WHITE}",
+      "deprecated": true
     },
     "BACKGROUND_ALTERNATIVE_SECONDARY_DARK_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!BLACK_TINT_01}"
+      "value": "{!BLACK_TINT_01}",
+      "deprecated": true
     },
     "BACKGROUND_TERTIARY_LIGHT_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!WHITE}"
+      "value": "{!WHITE}",
+      "deprecated": true
     },
     "BACKGROUND_TERTIARY_DARK_COLOR": {
       "type": "color",
       "category": "colors",
-      "value": "{!BLACK_TINT_02}"
+      "value": "{!BLACK_TINT_02}",
+      "deprecated": true
     },
     "BACKGROUND_ELEVATION_01_LIGHT_COLOR": {
       "type": "color",
       "category": "text-colors",
-      "value": "{!WHITE}"
+      "value": "{!WHITE}",
+      "deprecated": true
     },
     "BACKGROUND_ELEVATION_01_DARK_COLOR": {
       "type": "color",
       "category": "text-colors",
-      "value": "{!BLACK_TINT_01}"
+      "value": "{!BLACK_TINT_01}",
+      "deprecated": true
     },
     "BACKGROUND_ELEVATION_02_LIGHT_COLOR": {
       "type": "color",
       "category": "text-colors",
-      "value": "{!WHITE}"
+      "value": "{!WHITE}",
+      "deprecated": true
     },
     "BACKGROUND_ELEVATION_02_DARK_COLOR": {
       "type": "color",
       "category": "text-colors",
-      "value": "{!BLACK_TINT_02}"
+      "value": "{!BLACK_TINT_02}",
+      "deprecated": true
     },
     "BACKGROUND_ELEVATION_03_LIGHT_COLOR": {
       "type": "color",
       "category": "text-colors",
-      "value": "{!WHITE}"
+      "value": "{!WHITE}",
+      "deprecated": true
     },
     "BACKGROUND_ELEVATION_03_DARK_COLOR": {
       "type": "color",
       "category": "text-colors",
-      "value": "{!BLACK_TINT_03}"
+      "value": "{!BLACK_TINT_03}",
+      "deprecated": true
     }
   }
 }

--- a/packages/bpk-foundations-common/base/colors/text.json
+++ b/packages/bpk-foundations-common/base/colors/text.json
@@ -8,28 +8,36 @@
   },
   "props": {
     "TEXT_PRIMARY_LIGHT_COLOR": {
-      "value": "{!SKY_GRAY}"
+      "value": "{!SKY_GRAY}",
+      "deprecated": true
     },
     "TEXT_SECONDARY_LIGHT_COLOR": {
-      "value": "{!SKY_GRAY_TINT_02}"
+      "value": "{!SKY_GRAY_TINT_02}",
+      "deprecated": true
     },
     "TEXT_TERTIARY_LIGHT_COLOR": {
-      "value": "{!SKY_GRAY_TINT_03}"
+      "value": "{!SKY_GRAY_TINT_03}",
+      "deprecated": true
     },
     "TEXT_QUATERNARY_LIGHT_COLOR": {
-      "value": "{!SKY_GRAY_TINT_03}"
+      "value": "{!SKY_GRAY_TINT_03}",
+      "deprecated": true
     },
     "TEXT_PRIMARY_DARK_COLOR": {
-      "value": "{!WHITE}"
+      "value": "{!WHITE}",
+      "deprecated": true
     },
     "TEXT_SECONDARY_DARK_COLOR": {
-      "value": "{!SKY_GRAY_TINT_04}"
+      "value": "{!SKY_GRAY_TINT_04}",
+      "deprecated": true
     },
     "TEXT_TERTIARY_DARK_COLOR": {
-      "value": "{!BLACK_TINT_06}"
+      "value": "{!BLACK_TINT_06}",
+      "deprecated": true
     },
     "TEXT_QUATERNARY_DARK_COLOR": {
-      "value": "{!BLACK_TINT_06}"
+      "value": "{!BLACK_TINT_06}",
+      "deprecated": true
     },
     "TEXT_PRIMARY_DAY": {
       "value": "{!CHARCOAL}"

--- a/packages/bpk-foundations-ios/tokens/base.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.ios.json
@@ -25,6 +25,7 @@
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "backgroundAlternativeDarkColor"
     },
@@ -32,6 +33,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "backgroundAlternativeLightColor"
     },
@@ -39,6 +41,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "backgroundAlternativeSecondaryDarkColor"
     },
@@ -46,6 +49,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundAlternativeSecondaryLightColor"
     },
@@ -53,6 +57,7 @@
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "backgroundDarkColor"
     },
@@ -60,6 +65,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "backgroundElevation01DarkColor"
     },
@@ -67,6 +73,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundElevation01LightColor"
     },
@@ -74,6 +81,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "backgroundElevation02DarkColor"
     },
@@ -81,6 +89,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundElevation02LightColor"
     },
@@ -88,6 +97,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "backgroundElevation03DarkColor"
     },
@@ -95,6 +105,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundElevation03LightColor"
     },
@@ -102,6 +113,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundLightColor"
     },
@@ -109,6 +121,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "backgroundSecondaryDarkColor"
     },
@@ -116,6 +129,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "backgroundSecondaryLightColor"
     },
@@ -123,6 +137,7 @@
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "backgroundTertiaryDarkColor"
     },
@@ -130,6 +145,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundTertiaryLightColor"
     },
@@ -298,6 +314,7 @@
       "type": "color",
       "category": "colors",
       "value": "#5a489bff",
+      "deprecated": true,
       "originalValue": "{!ABISKO}",
       "name": "colorAbisko"
     },
@@ -305,6 +322,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffebd0ff",
+      "deprecated": true,
       "originalValue": "{!BAGAN}",
       "name": "colorBagan"
     },
@@ -319,6 +337,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "colorBlackTint01"
     },
@@ -326,6 +345,7 @@
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "colorBlackTint02"
     },
@@ -333,6 +353,7 @@
       "type": "color",
       "category": "colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "colorBlackTint03"
     },
@@ -340,6 +361,7 @@
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "colorBlackTint04"
     },
@@ -347,6 +369,7 @@
       "type": "color",
       "category": "colors",
       "value": "#636366ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_05}",
       "name": "colorBlackTint05"
     },
@@ -354,6 +377,7 @@
       "type": "color",
       "category": "colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "colorBlackTint06"
     },
@@ -361,6 +385,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ff7b59ff",
+      "deprecated": true,
       "originalValue": "{!BUNOL}",
       "name": "colorBunol"
     },
@@ -368,6 +393,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffb54dff",
+      "deprecated": true,
       "originalValue": "{!ERFOUD}",
       "name": "colorErfoud"
     },
@@ -375,6 +401,7 @@
       "type": "color",
       "category": "colors",
       "value": "#73cec6ff",
+      "deprecated": true,
       "originalValue": "{!GLENCOE}",
       "name": "colorGlencoe"
     },
@@ -382,6 +409,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f6dde1ff",
+      "deprecated": true,
       "originalValue": "{!HARBOUR}",
       "name": "colorHarbour"
     },
@@ -389,6 +417,7 @@
       "type": "color",
       "category": "colors",
       "value": "#e18b96ff",
+      "deprecated": true,
       "originalValue": "{!HILLIER}",
       "name": "colorHillier"
     },
@@ -396,6 +425,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ff9400ff",
+      "deprecated": true,
       "originalValue": "{!KOLKATA}",
       "name": "colorKolkata"
     },
@@ -403,6 +433,7 @@
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "colorMonteverde"
     },
@@ -410,6 +441,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffe7e0ff",
+      "deprecated": true,
       "originalValue": "{!NARA}",
       "name": "colorNara"
     },
@@ -417,6 +449,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "colorPanjin"
     },
@@ -424,6 +457,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffab95ff",
+      "deprecated": true,
       "originalValue": "{!PETRA}",
       "name": "colorPetra"
     },
@@ -431,6 +465,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "colorPrimaryGradientLight"
     },
@@ -438,6 +473,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d0eeecff",
+      "deprecated": true,
       "originalValue": "{!SAGANO}",
       "name": "colorSagano"
     },
@@ -452,6 +488,7 @@
       "type": "color",
       "category": "colors",
       "value": "#084eb2ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_01}",
       "name": "colorSkyBlueShade01"
     },
@@ -459,6 +496,7 @@
       "type": "color",
       "category": "colors",
       "value": "#042759ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_02}",
       "name": "colorSkyBlueShade02"
     },
@@ -466,6 +504,7 @@
       "type": "color",
       "category": "colors",
       "value": "#02122cff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_03}",
       "name": "colorSkyBlueShade03"
     },
@@ -473,6 +512,7 @@
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "colorSkyBlueTint01"
     },
@@ -480,6 +520,7 @@
       "type": "color",
       "category": "colors",
       "value": "#9dc0f2ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_02}",
       "name": "colorSkyBlueTint02"
     },
@@ -487,6 +528,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cddff8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_03}",
       "name": "colorSkyBlueTint03"
     },
@@ -494,6 +536,7 @@
       "type": "color",
       "category": "colors",
       "value": "#111236ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "colorSkyGray"
     },
@@ -501,6 +544,7 @@
       "type": "color",
       "category": "colors",
       "value": "#444560ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_01}",
       "name": "colorSkyGrayTint01"
     },
@@ -508,6 +552,7 @@
       "type": "color",
       "category": "colors",
       "value": "#68697fff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "colorSkyGrayTint02"
     },
@@ -515,6 +560,7 @@
       "type": "color",
       "category": "colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "colorSkyGrayTint03"
     },
@@ -522,6 +568,7 @@
       "type": "color",
       "category": "colors",
       "value": "#b2b2bfff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "colorSkyGrayTint04"
     },
@@ -529,6 +576,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "colorSkyGrayTint05"
     },
@@ -536,6 +584,7 @@
       "type": "color",
       "category": "colors",
       "value": "#dddde5ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_06}",
       "name": "colorSkyGrayTint06"
     },
@@ -543,6 +592,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "colorSkyGrayTint07"
     },
@@ -550,6 +600,7 @@
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "colorSystemGreen"
     },
@@ -557,6 +608,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "colorSystemRed"
     },
@@ -564,6 +616,7 @@
       "type": "color",
       "category": "colors",
       "value": "#e1ddecff",
+      "deprecated": true,
       "originalValue": "{!TOCHIGI}",
       "name": "colorTochigi"
     },
@@ -571,6 +624,7 @@
       "type": "color",
       "category": "colors",
       "value": "#a59bc8ff",
+      "deprecated": true,
       "originalValue": "{!VALENSOLE}",
       "name": "colorValensole"
     },
@@ -824,6 +878,7 @@
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "lineDarkColor"
     },
@@ -943,6 +998,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "lineLightColor"
     },
@@ -1076,6 +1132,7 @@
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "primaryDarkColor"
     },
@@ -1083,6 +1140,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "primaryLightColor"
     },
@@ -1981,6 +2039,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "textPrimaryDarkColor"
     },
@@ -2009,6 +2068,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#111236ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "textPrimaryLightColor"
     },
@@ -2023,6 +2083,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "textQuaternaryDarkColor"
     },
@@ -2030,6 +2091,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "textQuaternaryLightColor"
     },
@@ -2037,6 +2099,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#b2b2bfff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "textSecondaryDarkColor"
     },
@@ -2051,6 +2114,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#68697fff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "textSecondaryLightColor"
     },
@@ -2142,6 +2206,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "textTertiaryDarkColor"
     },
@@ -2149,6 +2214,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "textTertiaryLightColor"
     },
@@ -2430,6 +2496,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "backgroundAlternativeColor",
       "darkValue": "#000000ff",
@@ -2439,6 +2506,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundAlternativeSecondaryColor",
       "darkValue": "#1d1b20ff",
@@ -2448,6 +2516,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundColor",
       "darkValue": "#000000ff",
@@ -2457,6 +2526,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundElevation01Color",
       "darkValue": "#1d1b20ff",
@@ -2466,6 +2536,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundElevation02Color",
       "darkValue": "#2c2c2eff",
@@ -2475,6 +2546,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundElevation03Color",
       "darkValue": "#3a3a3cff",
@@ -2484,6 +2556,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "backgroundSecondaryColor",
       "darkValue": "#1d1b20ff",
@@ -2493,6 +2566,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "backgroundTertiaryColor",
       "darkValue": "#2c2c2eff",
@@ -2547,6 +2621,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "lineColor",
       "darkValue": "#48484aff",
@@ -2556,6 +2631,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "primaryColor",
       "darkValue": "#6d9febff",
@@ -2709,6 +2785,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#111236ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "textPrimaryColor",
       "darkValue": "#ffffffff",
@@ -2727,6 +2804,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "textQuaternaryColor",
       "darkValue": "#8e8e93ff",
@@ -2736,6 +2814,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#68697fff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "textSecondaryColor",
       "darkValue": "#b2b2bfff",
@@ -2745,6 +2824,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "textTertiaryColor",
       "darkValue": "#8e8e93ff",

--- a/packages/bpk-foundations-ios/tokens/base.raw.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.raw.ios.json
@@ -420,6 +420,7 @@
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_ALTERNATIVE_DARK_COLOR"
     },
@@ -427,6 +428,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_ALTERNATIVE_LIGHT_COLOR"
     },
@@ -434,6 +436,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_DARK_COLOR"
     },
@@ -441,6 +444,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_LIGHT_COLOR"
     },
@@ -448,6 +452,7 @@
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_DARK_COLOR"
     },
@@ -455,6 +460,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ELEVATION_01_DARK_COLOR"
     },
@@ -462,6 +468,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_01_LIGHT_COLOR"
     },
@@ -469,6 +476,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_ELEVATION_02_DARK_COLOR"
     },
@@ -476,6 +484,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_02_LIGHT_COLOR"
     },
@@ -483,6 +492,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "BACKGROUND_ELEVATION_03_DARK_COLOR"
     },
@@ -490,6 +500,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_03_LIGHT_COLOR"
     },
@@ -497,6 +508,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_LIGHT_COLOR"
     },
@@ -504,6 +516,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_SECONDARY_DARK_COLOR"
     },
@@ -511,6 +524,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_SECONDARY_LIGHT_COLOR"
     },
@@ -518,6 +532,7 @@
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_TERTIARY_DARK_COLOR"
     },
@@ -525,6 +540,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_TERTIARY_LIGHT_COLOR"
     },
@@ -693,6 +709,7 @@
       "type": "color",
       "category": "colors",
       "value": "#5a489bff",
+      "deprecated": true,
       "originalValue": "{!ABISKO}",
       "name": "COLOR_ABISKO"
     },
@@ -700,6 +717,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffebd0ff",
+      "deprecated": true,
       "originalValue": "{!BAGAN}",
       "name": "COLOR_BAGAN"
     },
@@ -714,6 +732,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "COLOR_BLACK_TINT_01"
     },
@@ -721,6 +740,7 @@
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "COLOR_BLACK_TINT_02"
     },
@@ -728,6 +748,7 @@
       "type": "color",
       "category": "colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "COLOR_BLACK_TINT_03"
     },
@@ -735,6 +756,7 @@
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "COLOR_BLACK_TINT_04"
     },
@@ -742,6 +764,7 @@
       "type": "color",
       "category": "colors",
       "value": "#636366ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_05}",
       "name": "COLOR_BLACK_TINT_05"
     },
@@ -749,6 +772,7 @@
       "type": "color",
       "category": "colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "COLOR_BLACK_TINT_06"
     },
@@ -756,6 +780,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ff7b59ff",
+      "deprecated": true,
       "originalValue": "{!BUNOL}",
       "name": "COLOR_BUNOL"
     },
@@ -763,6 +788,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffb54dff",
+      "deprecated": true,
       "originalValue": "{!ERFOUD}",
       "name": "COLOR_ERFOUD"
     },
@@ -770,6 +796,7 @@
       "type": "color",
       "category": "colors",
       "value": "#73cec6ff",
+      "deprecated": true,
       "originalValue": "{!GLENCOE}",
       "name": "COLOR_GLENCOE"
     },
@@ -777,6 +804,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f6dde1ff",
+      "deprecated": true,
       "originalValue": "{!HARBOUR}",
       "name": "COLOR_HARBOUR"
     },
@@ -784,6 +812,7 @@
       "type": "color",
       "category": "colors",
       "value": "#e18b96ff",
+      "deprecated": true,
       "originalValue": "{!HILLIER}",
       "name": "COLOR_HILLIER"
     },
@@ -791,6 +820,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ff9400ff",
+      "deprecated": true,
       "originalValue": "{!KOLKATA}",
       "name": "COLOR_KOLKATA"
     },
@@ -798,6 +828,7 @@
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_MONTEVERDE"
     },
@@ -805,6 +836,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffe7e0ff",
+      "deprecated": true,
       "originalValue": "{!NARA}",
       "name": "COLOR_NARA"
     },
@@ -812,6 +844,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_PANJIN"
     },
@@ -819,6 +852,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffab95ff",
+      "deprecated": true,
       "originalValue": "{!PETRA}",
       "name": "COLOR_PETRA"
     },
@@ -826,6 +860,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "COLOR_PRIMARY_GRADIENT_LIGHT"
     },
@@ -833,6 +868,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d0eeecff",
+      "deprecated": true,
       "originalValue": "{!SAGANO}",
       "name": "COLOR_SAGANO"
     },
@@ -847,6 +883,7 @@
       "type": "color",
       "category": "colors",
       "value": "#084eb2ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_01}",
       "name": "COLOR_SKY_BLUE_SHADE_01"
     },
@@ -854,6 +891,7 @@
       "type": "color",
       "category": "colors",
       "value": "#042759ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_02}",
       "name": "COLOR_SKY_BLUE_SHADE_02"
     },
@@ -861,6 +899,7 @@
       "type": "color",
       "category": "colors",
       "value": "#02122cff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_03}",
       "name": "COLOR_SKY_BLUE_SHADE_03"
     },
@@ -868,6 +907,7 @@
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "COLOR_SKY_BLUE_TINT_01"
     },
@@ -875,6 +915,7 @@
       "type": "color",
       "category": "colors",
       "value": "#9dc0f2ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_02}",
       "name": "COLOR_SKY_BLUE_TINT_02"
     },
@@ -882,6 +923,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cddff8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_03}",
       "name": "COLOR_SKY_BLUE_TINT_03"
     },
@@ -889,6 +931,7 @@
       "type": "color",
       "category": "colors",
       "value": "#111236ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "COLOR_SKY_GRAY"
     },
@@ -896,6 +939,7 @@
       "type": "color",
       "category": "colors",
       "value": "#444560ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_01}",
       "name": "COLOR_SKY_GRAY_TINT_01"
     },
@@ -903,6 +947,7 @@
       "type": "color",
       "category": "colors",
       "value": "#68697fff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "COLOR_SKY_GRAY_TINT_02"
     },
@@ -910,6 +955,7 @@
       "type": "color",
       "category": "colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "COLOR_SKY_GRAY_TINT_03"
     },
@@ -917,6 +963,7 @@
       "type": "color",
       "category": "colors",
       "value": "#b2b2bfff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "COLOR_SKY_GRAY_TINT_04"
     },
@@ -924,6 +971,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "COLOR_SKY_GRAY_TINT_05"
     },
@@ -931,6 +979,7 @@
       "type": "color",
       "category": "colors",
       "value": "#dddde5ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_06}",
       "name": "COLOR_SKY_GRAY_TINT_06"
     },
@@ -938,6 +987,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "COLOR_SKY_GRAY_TINT_07"
     },
@@ -945,6 +995,7 @@
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_SYSTEM_GREEN"
     },
@@ -952,6 +1003,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_SYSTEM_RED"
     },
@@ -959,6 +1011,7 @@
       "type": "color",
       "category": "colors",
       "value": "#e1ddecff",
+      "deprecated": true,
       "originalValue": "{!TOCHIGI}",
       "name": "COLOR_TOCHIGI"
     },
@@ -966,6 +1019,7 @@
       "type": "color",
       "category": "colors",
       "value": "#a59bc8ff",
+      "deprecated": true,
       "originalValue": "{!VALENSOLE}",
       "name": "COLOR_VALENSOLE"
     },
@@ -1219,6 +1273,7 @@
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "LINE_DARK_COLOR"
     },
@@ -1338,6 +1393,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "LINE_LIGHT_COLOR"
     },
@@ -1471,6 +1527,7 @@
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "PRIMARY_DARK_COLOR"
     },
@@ -1478,6 +1535,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_LIGHT_COLOR"
     },
@@ -2376,6 +2434,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "TEXT_PRIMARY_DARK_COLOR"
     },
@@ -2404,6 +2463,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#111236ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "TEXT_PRIMARY_LIGHT_COLOR"
     },
@@ -2418,6 +2478,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_QUATERNARY_DARK_COLOR"
     },
@@ -2425,6 +2486,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_QUATERNARY_LIGHT_COLOR"
     },
@@ -2432,6 +2494,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#b2b2bfff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "TEXT_SECONDARY_DARK_COLOR"
     },
@@ -2446,6 +2509,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#68697fff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "TEXT_SECONDARY_LIGHT_COLOR"
     },
@@ -2537,6 +2601,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_TERTIARY_DARK_COLOR"
     },
@@ -2544,6 +2609,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_TERTIARY_LIGHT_COLOR"
     },
@@ -2825,6 +2891,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_ALTERNATIVE_COLOR",
       "darkValue": "#000000ff",
@@ -2834,6 +2901,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_COLOR",
       "darkValue": "#1d1b20ff",
@@ -2843,6 +2911,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_COLOR",
       "darkValue": "#000000ff",
@@ -2852,6 +2921,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_01_COLOR",
       "darkValue": "#1d1b20ff",
@@ -2861,6 +2931,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_02_COLOR",
       "darkValue": "#2c2c2eff",
@@ -2870,6 +2941,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_03_COLOR",
       "darkValue": "#3a3a3cff",
@@ -2879,6 +2951,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_SECONDARY_COLOR",
       "darkValue": "#1d1b20ff",
@@ -2888,6 +2961,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_TERTIARY_COLOR",
       "darkValue": "#2c2c2eff",
@@ -2942,6 +3016,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "LINE_COLOR",
       "darkValue": "#48484aff",
@@ -2951,6 +3026,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_COLOR",
       "darkValue": "#6d9febff",
@@ -3104,6 +3180,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#111236ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "TEXT_PRIMARY_COLOR",
       "darkValue": "#ffffffff",
@@ -3122,6 +3199,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_QUATERNARY_COLOR",
       "darkValue": "#8e8e93ff",
@@ -3131,6 +3209,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#68697fff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "TEXT_SECONDARY_COLOR",
       "darkValue": "#b2b2bfff",
@@ -3140,6 +3219,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_TERTIARY_COLOR",
       "darkValue": "#8e8e93ff",

--- a/packages/bpk-foundations-react-native/tokens/base.ios.json
+++ b/packages/bpk-foundations-react-native/tokens/base.ios.json
@@ -4,36 +4,42 @@
       "type": "color",
       "category": "colors",
       "value": "#02122cff",
+      "deprecated": true,
       "name": "colorSkyBlueShade03"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "name": "colorPrimaryGradientLight"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#ffb54dff",
+      "deprecated": true,
       "name": "colorErfoud"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#a59bc8ff",
+      "deprecated": true,
       "name": "colorValensole"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "name": "colorMonteverde"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#444560ff",
+      "deprecated": true,
       "name": "colorSkyGrayTint01"
     },
     {
@@ -46,78 +52,91 @@
       "type": "color",
       "category": "colors",
       "value": "#68697fff",
+      "deprecated": true,
       "name": "colorSkyGrayTint02"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#d0eeecff",
+      "deprecated": true,
       "name": "colorSagano"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "name": "colorSkyGrayTint03"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#b2b2bfff",
+      "deprecated": true,
       "name": "colorSkyGrayTint04"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#f6dde1ff",
+      "deprecated": true,
       "name": "colorHarbour"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "name": "colorSkyGrayTint05"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#dddde5ff",
+      "deprecated": true,
       "name": "colorSkyGrayTint06"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "name": "colorBlackTint01"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "name": "colorSkyGrayTint07"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "name": "colorBlackTint02"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#5a489bff",
+      "deprecated": true,
       "name": "colorAbisko"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "name": "colorBlackTint03"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "name": "colorBlackTint04"
     },
     {
@@ -130,42 +149,49 @@
       "type": "color",
       "category": "colors",
       "value": "#636366ff",
+      "deprecated": true,
       "name": "colorBlackTint05"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "name": "colorBlackTint06"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "name": "colorPanjin"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#ff9400ff",
+      "deprecated": true,
       "name": "colorKolkata"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#73cec6ff",
+      "deprecated": true,
       "name": "colorGlencoe"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#e1ddecff",
+      "deprecated": true,
       "name": "colorTochigi"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#ffab95ff",
+      "deprecated": true,
       "name": "colorPetra"
     },
     {
@@ -178,60 +204,70 @@
       "type": "color",
       "category": "colors",
       "value": "#ffebd0ff",
+      "deprecated": true,
       "name": "colorBagan"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#e18b96ff",
+      "deprecated": true,
       "name": "colorHillier"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "name": "colorSkyBlueTint01"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#9dc0f2ff",
+      "deprecated": true,
       "name": "colorSkyBlueTint02"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#ff7b59ff",
+      "deprecated": true,
       "name": "colorBunol"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#cddff8ff",
+      "deprecated": true,
       "name": "colorSkyBlueTint03"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#111236ff",
+      "deprecated": true,
       "name": "colorSkyGray"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#ffe7e0ff",
+      "deprecated": true,
       "name": "colorNara"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#084eb2ff",
+      "deprecated": true,
       "name": "colorSkyBlueShade01"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#042759ff",
+      "deprecated": true,
       "name": "colorSkyBlueShade02"
     },
     {
@@ -569,48 +605,56 @@
       "type": "color",
       "category": "text-colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "name": "backgroundElevation03DarkColor"
     },
     {
       "type": "color",
       "category": "text-colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "name": "backgroundElevation02DarkColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "name": "lineDarkColor"
     },
     {
       "type": "color",
       "category": "text-colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "name": "backgroundElevation01DarkColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "name": "backgroundAlternativeSecondaryDarkColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundLightColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "name": "backgroundDarkColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundAlternativeSecondaryLightColor"
     },
     {
@@ -623,24 +667,28 @@
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "name": "colorSystemGreen"
     },
     {
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundElevation01LightColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "name": "lineLightColor"
     },
     {
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundElevation02LightColor"
     },
     {
@@ -653,60 +701,70 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundElevation03LightColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "name": "backgroundTertiaryDarkColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "name": "backgroundSecondaryDarkColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "name": "backgroundAlternativeLightColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "name": "primaryDarkColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "name": "colorSystemRed"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "name": "backgroundAlternativeDarkColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "name": "primaryLightColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundTertiaryLightColor"
     },
     {
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "name": "backgroundSecondaryLightColor"
     },
     {
@@ -1586,6 +1644,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundElevation03Color",
       "darkValue": "#3a3a3cff"
     },
@@ -1593,6 +1652,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundElevation02Color",
       "darkValue": "#2c2c2eff"
     },
@@ -1607,6 +1667,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundElevation01Color",
       "darkValue": "#1d1b20ff"
     },
@@ -1614,6 +1675,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundAlternativeSecondaryColor",
       "darkValue": "#1d1b20ff"
     },
@@ -1621,6 +1683,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundColor",
       "darkValue": "#000000ff"
     },
@@ -1628,6 +1691,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "name": "backgroundTertiaryColor",
       "darkValue": "#2c2c2eff"
     },
@@ -1635,6 +1699,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "name": "backgroundSecondaryColor",
       "darkValue": "#1d1b20ff"
     },
@@ -1642,6 +1707,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "name": "backgroundAlternativeColor",
       "darkValue": "#000000ff"
     },
@@ -1649,6 +1715,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "name": "primaryColor",
       "darkValue": "#6d9febff"
     }

--- a/packages/bpk-foundations-react-native/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-react-native/tokens/base.raw.android.json
@@ -396,6 +396,7 @@
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_ALTERNATIVE_DARK_COLOR"
     },
@@ -403,6 +404,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_ALTERNATIVE_LIGHT_COLOR"
     },
@@ -410,6 +412,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_DARK_COLOR"
     },
@@ -417,6 +420,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_LIGHT_COLOR"
     },
@@ -424,6 +428,7 @@
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_DARK_COLOR"
     },
@@ -431,6 +436,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ELEVATION_01_DARK_COLOR"
     },
@@ -438,6 +444,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_01_LIGHT_COLOR"
     },
@@ -445,6 +452,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_ELEVATION_02_DARK_COLOR"
     },
@@ -452,6 +460,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_02_LIGHT_COLOR"
     },
@@ -459,6 +468,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "BACKGROUND_ELEVATION_03_DARK_COLOR"
     },
@@ -466,6 +476,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_03_LIGHT_COLOR"
     },
@@ -473,6 +484,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_LIGHT_COLOR"
     },
@@ -480,6 +492,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_SECONDARY_DARK_COLOR"
     },
@@ -487,6 +500,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_SECONDARY_LIGHT_COLOR"
     },
@@ -494,6 +508,7 @@
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_TERTIARY_DARK_COLOR"
     },
@@ -501,6 +516,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_TERTIARY_LIGHT_COLOR"
     },
@@ -648,6 +664,7 @@
       "type": "color",
       "category": "colors",
       "value": "#5a489bff",
+      "deprecated": true,
       "originalValue": "{!ABISKO}",
       "name": "COLOR_ABISKO"
     },
@@ -655,6 +672,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffebd0ff",
+      "deprecated": true,
       "originalValue": "{!BAGAN}",
       "name": "COLOR_BAGAN"
     },
@@ -669,6 +687,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "COLOR_BLACK_TINT_01"
     },
@@ -676,6 +695,7 @@
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "COLOR_BLACK_TINT_02"
     },
@@ -683,6 +703,7 @@
       "type": "color",
       "category": "colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "COLOR_BLACK_TINT_03"
     },
@@ -690,6 +711,7 @@
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "COLOR_BLACK_TINT_04"
     },
@@ -697,6 +719,7 @@
       "type": "color",
       "category": "colors",
       "value": "#636366ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_05}",
       "name": "COLOR_BLACK_TINT_05"
     },
@@ -704,6 +727,7 @@
       "type": "color",
       "category": "colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "COLOR_BLACK_TINT_06"
     },
@@ -711,6 +735,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ff7b59ff",
+      "deprecated": true,
       "originalValue": "{!BUNOL}",
       "name": "COLOR_BUNOL"
     },
@@ -718,6 +743,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffb54dff",
+      "deprecated": true,
       "originalValue": "{!ERFOUD}",
       "name": "COLOR_ERFOUD"
     },
@@ -725,6 +751,7 @@
       "type": "color",
       "category": "colors",
       "value": "#73cec6ff",
+      "deprecated": true,
       "originalValue": "{!GLENCOE}",
       "name": "COLOR_GLENCOE"
     },
@@ -732,6 +759,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f6dde1ff",
+      "deprecated": true,
       "originalValue": "{!HARBOUR}",
       "name": "COLOR_HARBOUR"
     },
@@ -739,6 +767,7 @@
       "type": "color",
       "category": "colors",
       "value": "#e18b96ff",
+      "deprecated": true,
       "originalValue": "{!HILLIER}",
       "name": "COLOR_HILLIER"
     },
@@ -746,6 +775,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ff9400ff",
+      "deprecated": true,
       "originalValue": "{!KOLKATA}",
       "name": "COLOR_KOLKATA"
     },
@@ -753,6 +783,7 @@
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_MONTEVERDE"
     },
@@ -760,6 +791,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffe7e0ff",
+      "deprecated": true,
       "originalValue": "{!NARA}",
       "name": "COLOR_NARA"
     },
@@ -767,6 +799,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_PANJIN"
     },
@@ -774,6 +807,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffab95ff",
+      "deprecated": true,
       "originalValue": "{!PETRA}",
       "name": "COLOR_PETRA"
     },
@@ -781,6 +815,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "COLOR_PRIMARY_GRADIENT_LIGHT"
     },
@@ -788,6 +823,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d0eeecff",
+      "deprecated": true,
       "originalValue": "{!SAGANO}",
       "name": "COLOR_SAGANO"
     },
@@ -802,6 +838,7 @@
       "type": "color",
       "category": "colors",
       "value": "#084eb2ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_01}",
       "name": "COLOR_SKY_BLUE_SHADE_01"
     },
@@ -809,6 +846,7 @@
       "type": "color",
       "category": "colors",
       "value": "#042759ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_02}",
       "name": "COLOR_SKY_BLUE_SHADE_02"
     },
@@ -816,6 +854,7 @@
       "type": "color",
       "category": "colors",
       "value": "#02122cff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_03}",
       "name": "COLOR_SKY_BLUE_SHADE_03"
     },
@@ -823,6 +862,7 @@
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "COLOR_SKY_BLUE_TINT_01"
     },
@@ -830,6 +870,7 @@
       "type": "color",
       "category": "colors",
       "value": "#9dc0f2ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_02}",
       "name": "COLOR_SKY_BLUE_TINT_02"
     },
@@ -837,6 +878,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cddff8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_03}",
       "name": "COLOR_SKY_BLUE_TINT_03"
     },
@@ -844,6 +886,7 @@
       "type": "color",
       "category": "colors",
       "value": "#111236ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "COLOR_SKY_GRAY"
     },
@@ -851,6 +894,7 @@
       "type": "color",
       "category": "colors",
       "value": "#444560ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_01}",
       "name": "COLOR_SKY_GRAY_TINT_01"
     },
@@ -858,6 +902,7 @@
       "type": "color",
       "category": "colors",
       "value": "#68697fff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "COLOR_SKY_GRAY_TINT_02"
     },
@@ -865,6 +910,7 @@
       "type": "color",
       "category": "colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "COLOR_SKY_GRAY_TINT_03"
     },
@@ -872,6 +918,7 @@
       "type": "color",
       "category": "colors",
       "value": "#b2b2bfff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "COLOR_SKY_GRAY_TINT_04"
     },
@@ -879,6 +926,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "COLOR_SKY_GRAY_TINT_05"
     },
@@ -886,6 +934,7 @@
       "type": "color",
       "category": "colors",
       "value": "#dddde5ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_06}",
       "name": "COLOR_SKY_GRAY_TINT_06"
     },
@@ -893,6 +942,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "COLOR_SKY_GRAY_TINT_07"
     },
@@ -900,6 +950,7 @@
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_SYSTEM_GREEN"
     },
@@ -907,6 +958,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_SYSTEM_RED"
     },
@@ -914,6 +966,7 @@
       "type": "color",
       "category": "colors",
       "value": "#e1ddecff",
+      "deprecated": true,
       "originalValue": "{!TOCHIGI}",
       "name": "COLOR_TOCHIGI"
     },
@@ -921,6 +974,7 @@
       "type": "color",
       "category": "colors",
       "value": "#a59bc8ff",
+      "deprecated": true,
       "originalValue": "{!VALENSOLE}",
       "name": "COLOR_VALENSOLE"
     },
@@ -1152,6 +1206,7 @@
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "LINE_DARK_COLOR"
     },
@@ -1208,6 +1263,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "LINE_LIGHT_COLOR"
     },
@@ -1341,6 +1397,7 @@
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "PRIMARY_DARK_COLOR"
     },
@@ -1348,6 +1405,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_LIGHT_COLOR"
     },
@@ -1909,6 +1967,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_ALTERNATIVE_COLOR",
       "darkValue": "#000000ff",
@@ -1918,6 +1977,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_COLOR",
       "darkValue": "#1d1b20ff",
@@ -1927,6 +1987,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_COLOR",
       "darkValue": "#000000ff",
@@ -1936,6 +1997,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_01_COLOR",
       "darkValue": "#1d1b20ff",
@@ -1945,6 +2007,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_02_COLOR",
       "darkValue": "#2c2c2eff",
@@ -1954,6 +2017,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_03_COLOR",
       "darkValue": "#3a3a3cff",
@@ -1963,6 +2027,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_SECONDARY_COLOR",
       "darkValue": "#1d1b20ff",
@@ -1972,6 +2037,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_TERTIARY_COLOR",
       "darkValue": "#2c2c2eff",
@@ -2026,6 +2092,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "LINE_COLOR",
       "darkValue": "#48484aff",
@@ -2035,6 +2102,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_COLOR",
       "darkValue": "#6d9febff",

--- a/packages/bpk-foundations-react-native/tokens/base.raw.ios.json
+++ b/packages/bpk-foundations-react-native/tokens/base.raw.ios.json
@@ -375,6 +375,7 @@
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_ALTERNATIVE_DARK_COLOR"
     },
@@ -382,6 +383,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_ALTERNATIVE_LIGHT_COLOR"
     },
@@ -389,6 +391,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_DARK_COLOR"
     },
@@ -396,6 +399,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_LIGHT_COLOR"
     },
@@ -403,6 +407,7 @@
       "type": "color",
       "category": "colors",
       "value": "#000000ff",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_DARK_COLOR"
     },
@@ -410,6 +415,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ELEVATION_01_DARK_COLOR"
     },
@@ -417,6 +423,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_01_LIGHT_COLOR"
     },
@@ -424,6 +431,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_ELEVATION_02_DARK_COLOR"
     },
@@ -431,6 +439,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_02_LIGHT_COLOR"
     },
@@ -438,6 +447,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "BACKGROUND_ELEVATION_03_DARK_COLOR"
     },
@@ -445,6 +455,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_03_LIGHT_COLOR"
     },
@@ -452,6 +463,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_LIGHT_COLOR"
     },
@@ -459,6 +471,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_SECONDARY_DARK_COLOR"
     },
@@ -466,6 +479,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_SECONDARY_LIGHT_COLOR"
     },
@@ -473,6 +487,7 @@
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_TERTIARY_DARK_COLOR"
     },
@@ -480,6 +495,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_TERTIARY_LIGHT_COLOR"
     },
@@ -648,6 +664,7 @@
       "type": "color",
       "category": "colors",
       "value": "#5a489bff",
+      "deprecated": true,
       "originalValue": "{!ABISKO}",
       "name": "COLOR_ABISKO"
     },
@@ -655,6 +672,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffebd0ff",
+      "deprecated": true,
       "originalValue": "{!BAGAN}",
       "name": "COLOR_BAGAN"
     },
@@ -669,6 +687,7 @@
       "type": "color",
       "category": "colors",
       "value": "#1d1b20ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "COLOR_BLACK_TINT_01"
     },
@@ -676,6 +695,7 @@
       "type": "color",
       "category": "colors",
       "value": "#2c2c2eff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "COLOR_BLACK_TINT_02"
     },
@@ -683,6 +703,7 @@
       "type": "color",
       "category": "colors",
       "value": "#3a3a3cff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "COLOR_BLACK_TINT_03"
     },
@@ -690,6 +711,7 @@
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "COLOR_BLACK_TINT_04"
     },
@@ -697,6 +719,7 @@
       "type": "color",
       "category": "colors",
       "value": "#636366ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_05}",
       "name": "COLOR_BLACK_TINT_05"
     },
@@ -704,6 +727,7 @@
       "type": "color",
       "category": "colors",
       "value": "#8e8e93ff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "COLOR_BLACK_TINT_06"
     },
@@ -711,6 +735,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ff7b59ff",
+      "deprecated": true,
       "originalValue": "{!BUNOL}",
       "name": "COLOR_BUNOL"
     },
@@ -718,6 +743,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffb54dff",
+      "deprecated": true,
       "originalValue": "{!ERFOUD}",
       "name": "COLOR_ERFOUD"
     },
@@ -725,6 +751,7 @@
       "type": "color",
       "category": "colors",
       "value": "#73cec6ff",
+      "deprecated": true,
       "originalValue": "{!GLENCOE}",
       "name": "COLOR_GLENCOE"
     },
@@ -732,6 +759,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f6dde1ff",
+      "deprecated": true,
       "originalValue": "{!HARBOUR}",
       "name": "COLOR_HARBOUR"
     },
@@ -739,6 +767,7 @@
       "type": "color",
       "category": "colors",
       "value": "#e18b96ff",
+      "deprecated": true,
       "originalValue": "{!HILLIER}",
       "name": "COLOR_HILLIER"
     },
@@ -746,6 +775,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ff9400ff",
+      "deprecated": true,
       "originalValue": "{!KOLKATA}",
       "name": "COLOR_KOLKATA"
     },
@@ -753,6 +783,7 @@
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_MONTEVERDE"
     },
@@ -760,6 +791,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffe7e0ff",
+      "deprecated": true,
       "originalValue": "{!NARA}",
       "name": "COLOR_NARA"
     },
@@ -767,6 +799,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_PANJIN"
     },
@@ -774,6 +807,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffab95ff",
+      "deprecated": true,
       "originalValue": "{!PETRA}",
       "name": "COLOR_PETRA"
     },
@@ -781,6 +815,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "COLOR_PRIMARY_GRADIENT_LIGHT"
     },
@@ -788,6 +823,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d0eeecff",
+      "deprecated": true,
       "originalValue": "{!SAGANO}",
       "name": "COLOR_SAGANO"
     },
@@ -802,6 +838,7 @@
       "type": "color",
       "category": "colors",
       "value": "#084eb2ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_01}",
       "name": "COLOR_SKY_BLUE_SHADE_01"
     },
@@ -809,6 +846,7 @@
       "type": "color",
       "category": "colors",
       "value": "#042759ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_02}",
       "name": "COLOR_SKY_BLUE_SHADE_02"
     },
@@ -816,6 +854,7 @@
       "type": "color",
       "category": "colors",
       "value": "#02122cff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_03}",
       "name": "COLOR_SKY_BLUE_SHADE_03"
     },
@@ -823,6 +862,7 @@
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "COLOR_SKY_BLUE_TINT_01"
     },
@@ -830,6 +870,7 @@
       "type": "color",
       "category": "colors",
       "value": "#9dc0f2ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_02}",
       "name": "COLOR_SKY_BLUE_TINT_02"
     },
@@ -837,6 +878,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cddff8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_03}",
       "name": "COLOR_SKY_BLUE_TINT_03"
     },
@@ -844,6 +886,7 @@
       "type": "color",
       "category": "colors",
       "value": "#111236ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "COLOR_SKY_GRAY"
     },
@@ -851,6 +894,7 @@
       "type": "color",
       "category": "colors",
       "value": "#444560ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_01}",
       "name": "COLOR_SKY_GRAY_TINT_01"
     },
@@ -858,6 +902,7 @@
       "type": "color",
       "category": "colors",
       "value": "#68697fff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "COLOR_SKY_GRAY_TINT_02"
     },
@@ -865,6 +910,7 @@
       "type": "color",
       "category": "colors",
       "value": "#8f90a0ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "COLOR_SKY_GRAY_TINT_03"
     },
@@ -872,6 +918,7 @@
       "type": "color",
       "category": "colors",
       "value": "#b2b2bfff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "COLOR_SKY_GRAY_TINT_04"
     },
@@ -879,6 +926,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "COLOR_SKY_GRAY_TINT_05"
     },
@@ -886,6 +934,7 @@
       "type": "color",
       "category": "colors",
       "value": "#dddde5ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_06}",
       "name": "COLOR_SKY_GRAY_TINT_06"
     },
@@ -893,6 +942,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "COLOR_SKY_GRAY_TINT_07"
     },
@@ -900,6 +950,7 @@
       "type": "color",
       "category": "colors",
       "value": "#00a698ff",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_SYSTEM_GREEN"
     },
@@ -907,6 +958,7 @@
       "type": "color",
       "category": "colors",
       "value": "#d1435bff",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_SYSTEM_RED"
     },
@@ -914,6 +966,7 @@
       "type": "color",
       "category": "colors",
       "value": "#e1ddecff",
+      "deprecated": true,
       "originalValue": "{!TOCHIGI}",
       "name": "COLOR_TOCHIGI"
     },
@@ -921,6 +974,7 @@
       "type": "color",
       "category": "colors",
       "value": "#a59bc8ff",
+      "deprecated": true,
       "originalValue": "{!VALENSOLE}",
       "name": "COLOR_VALENSOLE"
     },
@@ -1131,6 +1185,7 @@
       "type": "color",
       "category": "colors",
       "value": "#48484aff",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "LINE_DARK_COLOR"
     },
@@ -1187,6 +1242,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "LINE_LIGHT_COLOR"
     },
@@ -1320,6 +1376,7 @@
       "type": "color",
       "category": "colors",
       "value": "#6d9febff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "PRIMARY_DARK_COLOR"
     },
@@ -1327,6 +1384,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_LIGHT_COLOR"
     },
@@ -1987,6 +2045,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_ALTERNATIVE_COLOR",
       "darkValue": "#000000ff",
@@ -1996,6 +2055,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_COLOR",
       "darkValue": "#1d1b20ff",
@@ -2005,6 +2065,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_COLOR",
       "darkValue": "#000000ff",
@@ -2014,6 +2075,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_01_COLOR",
       "darkValue": "#1d1b20ff",
@@ -2023,6 +2085,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_02_COLOR",
       "darkValue": "#2c2c2eff",
@@ -2032,6 +2095,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_03_COLOR",
       "darkValue": "#3a3a3cff",
@@ -2041,6 +2105,7 @@
       "type": "color",
       "category": "colors",
       "value": "#f1f2f8ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_SECONDARY_COLOR",
       "darkValue": "#1d1b20ff",
@@ -2050,6 +2115,7 @@
       "type": "color",
       "category": "colors",
       "value": "#ffffffff",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_TERTIARY_COLOR",
       "darkValue": "#2c2c2eff",
@@ -2104,6 +2170,7 @@
       "type": "color",
       "category": "colors",
       "value": "#cdcdd7ff",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "LINE_COLOR",
       "darkValue": "#48484aff",
@@ -2113,6 +2180,7 @@
       "type": "color",
       "category": "colors",
       "value": "#0770e3ff",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_COLOR",
       "darkValue": "#6d9febff",

--- a/packages/bpk-foundations-web/tokens/base.raw.json
+++ b/packages/bpk-foundations-web/tokens/base.raw.json
@@ -462,6 +462,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(2, 18, 44)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_03}",
       "name": "COLOR_SKY_BLUE_SHADE_03"
     },
@@ -469,6 +470,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(7, 112, 227)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "COLOR_PRIMARY_GRADIENT_LIGHT"
     },
@@ -476,6 +478,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 181, 77)",
+      "deprecated": true,
       "originalValue": "{!ERFOUD}",
       "name": "COLOR_ERFOUD"
     },
@@ -483,6 +486,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(165, 155, 200)",
+      "deprecated": true,
       "originalValue": "{!VALENSOLE}",
       "name": "COLOR_VALENSOLE"
     },
@@ -490,6 +494,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 166, 152)",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_MONTEVERDE"
     },
@@ -497,6 +502,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(68, 69, 96)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_01}",
       "name": "COLOR_SKY_GRAY_TINT_01"
     },
@@ -511,6 +517,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(104, 105, 127)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "COLOR_SKY_GRAY_TINT_02"
     },
@@ -518,6 +525,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(208, 238, 236)",
+      "deprecated": true,
       "originalValue": "{!SAGANO}",
       "name": "COLOR_SAGANO"
     },
@@ -525,6 +533,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(143, 144, 160)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "COLOR_SKY_GRAY_TINT_03"
     },
@@ -532,6 +541,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(178, 178, 191)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "COLOR_SKY_GRAY_TINT_04"
     },
@@ -539,6 +549,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(246, 221, 225)",
+      "deprecated": true,
       "originalValue": "{!HARBOUR}",
       "name": "COLOR_HARBOUR"
     },
@@ -546,6 +557,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(205, 205, 215)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "COLOR_SKY_GRAY_TINT_05"
     },
@@ -553,6 +565,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(221, 221, 229)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_06}",
       "name": "COLOR_SKY_GRAY_TINT_06"
     },
@@ -560,6 +573,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(29, 27, 32)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "COLOR_BLACK_TINT_01"
     },
@@ -567,6 +581,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(241, 242, 248)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "COLOR_SKY_GRAY_TINT_07"
     },
@@ -574,6 +589,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(44, 44, 46)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "COLOR_BLACK_TINT_02"
     },
@@ -581,6 +597,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(90, 72, 155)",
+      "deprecated": true,
       "originalValue": "{!ABISKO}",
       "name": "COLOR_ABISKO"
     },
@@ -588,6 +605,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(58, 58, 60)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "COLOR_BLACK_TINT_03"
     },
@@ -595,6 +613,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(72, 72, 74)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "COLOR_BLACK_TINT_04"
     },
@@ -609,6 +628,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(99, 99, 102)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_05}",
       "name": "COLOR_BLACK_TINT_05"
     },
@@ -616,6 +636,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(142, 142, 147)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "COLOR_BLACK_TINT_06"
     },
@@ -623,6 +644,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(209, 67, 91)",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_PANJIN"
     },
@@ -630,6 +652,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 148, 0)",
+      "deprecated": true,
       "originalValue": "{!KOLKATA}",
       "name": "COLOR_KOLKATA"
     },
@@ -637,6 +660,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(115, 206, 198)",
+      "deprecated": true,
       "originalValue": "{!GLENCOE}",
       "name": "COLOR_GLENCOE"
     },
@@ -644,6 +668,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(225, 221, 236)",
+      "deprecated": true,
       "originalValue": "{!TOCHIGI}",
       "name": "COLOR_TOCHIGI"
     },
@@ -651,6 +676,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 171, 149)",
+      "deprecated": true,
       "originalValue": "{!PETRA}",
       "name": "COLOR_PETRA"
     },
@@ -665,6 +691,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 235, 208)",
+      "deprecated": true,
       "originalValue": "{!BAGAN}",
       "name": "COLOR_BAGAN"
     },
@@ -672,6 +699,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(225, 139, 150)",
+      "deprecated": true,
       "originalValue": "{!HILLIER}",
       "name": "COLOR_HILLIER"
     },
@@ -679,6 +707,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(109, 159, 235)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "COLOR_SKY_BLUE_TINT_01"
     },
@@ -686,6 +715,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(157, 192, 242)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_02}",
       "name": "COLOR_SKY_BLUE_TINT_02"
     },
@@ -693,6 +723,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 123, 89)",
+      "deprecated": true,
       "originalValue": "{!BUNOL}",
       "name": "COLOR_BUNOL"
     },
@@ -700,6 +731,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(205, 223, 248)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_03}",
       "name": "COLOR_SKY_BLUE_TINT_03"
     },
@@ -707,6 +739,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(17, 18, 54)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "COLOR_SKY_GRAY"
     },
@@ -714,6 +747,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 231, 224)",
+      "deprecated": true,
       "originalValue": "{!NARA}",
       "name": "COLOR_NARA"
     },
@@ -721,6 +755,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(8, 78, 178)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_01}",
       "name": "COLOR_SKY_BLUE_SHADE_01"
     },
@@ -728,6 +763,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(4, 39, 89)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_02}",
       "name": "COLOR_SKY_BLUE_SHADE_02"
     },
@@ -980,6 +1016,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "TEXT_PRIMARY_DARK_COLOR"
     },
@@ -994,6 +1031,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(142, 142, 147)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_QUATERNARY_DARK_COLOR"
     },
@@ -1008,6 +1046,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(143, 144, 160)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_QUATERNARY_LIGHT_COLOR"
     },
@@ -1022,6 +1061,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(17, 18, 54)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "TEXT_PRIMARY_LIGHT_COLOR"
     },
@@ -1050,6 +1090,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(142, 142, 147)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_TERTIARY_DARK_COLOR"
     },
@@ -1057,6 +1098,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(178, 178, 191)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "TEXT_SECONDARY_DARK_COLOR"
     },
@@ -1086,6 +1128,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(104, 105, 127)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "TEXT_SECONDARY_LIGHT_COLOR"
     },
@@ -1100,6 +1143,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(143, 144, 160)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_TERTIARY_LIGHT_COLOR"
     },
@@ -1121,6 +1165,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(58, 58, 60)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "BACKGROUND_ELEVATION_03_DARK_COLOR"
     },
@@ -1128,6 +1173,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(44, 44, 46)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_ELEVATION_02_DARK_COLOR"
     },
@@ -1135,6 +1181,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(72, 72, 74)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "LINE_DARK_COLOR"
     },
@@ -1142,6 +1189,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(29, 27, 32)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ELEVATION_01_DARK_COLOR"
     },
@@ -1149,6 +1197,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(29, 27, 32)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_DARK_COLOR"
     },
@@ -1156,6 +1205,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_LIGHT_COLOR"
     },
@@ -1163,6 +1213,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 0, 0)",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_DARK_COLOR"
     },
@@ -1170,6 +1221,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_LIGHT_COLOR"
     },
@@ -1184,6 +1236,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 166, 152)",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_SYSTEM_GREEN"
     },
@@ -1191,6 +1244,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_01_LIGHT_COLOR"
     },
@@ -1198,6 +1252,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(205, 205, 215)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "LINE_LIGHT_COLOR"
     },
@@ -1205,6 +1260,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_02_LIGHT_COLOR"
     },
@@ -1219,6 +1275,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_03_LIGHT_COLOR"
     },
@@ -1226,6 +1283,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(44, 44, 46)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_TERTIARY_DARK_COLOR"
     },
@@ -1233,6 +1291,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(29, 27, 32)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_SECONDARY_DARK_COLOR"
     },
@@ -1240,6 +1299,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(241, 242, 248)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_ALTERNATIVE_LIGHT_COLOR"
     },
@@ -1247,6 +1307,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(109, 159, 235)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "PRIMARY_DARK_COLOR"
     },
@@ -1254,6 +1315,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(209, 67, 91)",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_SYSTEM_RED"
     },
@@ -1261,6 +1323,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 0, 0)",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_ALTERNATIVE_DARK_COLOR"
     },
@@ -1268,6 +1331,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(7, 112, 227)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_LIGHT_COLOR"
     },
@@ -1275,6 +1339,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_TERTIARY_LIGHT_COLOR"
     },
@@ -1282,6 +1347,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(241, 242, 248)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_SECONDARY_LIGHT_COLOR"
     },

--- a/packages/bpk-foundations-web/tokens/breakpoints.raw.json
+++ b/packages/bpk-foundations-web/tokens/breakpoints.raw.json
@@ -441,6 +441,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(2, 18, 44)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_03}",
       "name": "COLOR_SKY_BLUE_SHADE_03"
     },
@@ -448,6 +449,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(7, 112, 227)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "COLOR_PRIMARY_GRADIENT_LIGHT"
     },
@@ -455,6 +457,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 181, 77)",
+      "deprecated": true,
       "originalValue": "{!ERFOUD}",
       "name": "COLOR_ERFOUD"
     },
@@ -462,6 +465,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(165, 155, 200)",
+      "deprecated": true,
       "originalValue": "{!VALENSOLE}",
       "name": "COLOR_VALENSOLE"
     },
@@ -469,6 +473,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 166, 152)",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_MONTEVERDE"
     },
@@ -476,6 +481,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(68, 69, 96)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_01}",
       "name": "COLOR_SKY_GRAY_TINT_01"
     },
@@ -490,6 +496,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(104, 105, 127)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "COLOR_SKY_GRAY_TINT_02"
     },
@@ -497,6 +504,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(208, 238, 236)",
+      "deprecated": true,
       "originalValue": "{!SAGANO}",
       "name": "COLOR_SAGANO"
     },
@@ -504,6 +512,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(143, 144, 160)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "COLOR_SKY_GRAY_TINT_03"
     },
@@ -511,6 +520,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(178, 178, 191)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "COLOR_SKY_GRAY_TINT_04"
     },
@@ -518,6 +528,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(246, 221, 225)",
+      "deprecated": true,
       "originalValue": "{!HARBOUR}",
       "name": "COLOR_HARBOUR"
     },
@@ -525,6 +536,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(205, 205, 215)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "COLOR_SKY_GRAY_TINT_05"
     },
@@ -532,6 +544,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(221, 221, 229)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_06}",
       "name": "COLOR_SKY_GRAY_TINT_06"
     },
@@ -539,6 +552,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(29, 27, 32)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "COLOR_BLACK_TINT_01"
     },
@@ -546,6 +560,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(241, 242, 248)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "COLOR_SKY_GRAY_TINT_07"
     },
@@ -553,6 +568,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(44, 44, 46)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "COLOR_BLACK_TINT_02"
     },
@@ -560,6 +576,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(90, 72, 155)",
+      "deprecated": true,
       "originalValue": "{!ABISKO}",
       "name": "COLOR_ABISKO"
     },
@@ -567,6 +584,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(58, 58, 60)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "COLOR_BLACK_TINT_03"
     },
@@ -574,6 +592,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(72, 72, 74)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "COLOR_BLACK_TINT_04"
     },
@@ -588,6 +607,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(99, 99, 102)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_05}",
       "name": "COLOR_BLACK_TINT_05"
     },
@@ -595,6 +615,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(142, 142, 147)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "COLOR_BLACK_TINT_06"
     },
@@ -602,6 +623,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(209, 67, 91)",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_PANJIN"
     },
@@ -609,6 +631,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 148, 0)",
+      "deprecated": true,
       "originalValue": "{!KOLKATA}",
       "name": "COLOR_KOLKATA"
     },
@@ -616,6 +639,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(115, 206, 198)",
+      "deprecated": true,
       "originalValue": "{!GLENCOE}",
       "name": "COLOR_GLENCOE"
     },
@@ -623,6 +647,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(225, 221, 236)",
+      "deprecated": true,
       "originalValue": "{!TOCHIGI}",
       "name": "COLOR_TOCHIGI"
     },
@@ -630,6 +655,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 171, 149)",
+      "deprecated": true,
       "originalValue": "{!PETRA}",
       "name": "COLOR_PETRA"
     },
@@ -644,6 +670,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 235, 208)",
+      "deprecated": true,
       "originalValue": "{!BAGAN}",
       "name": "COLOR_BAGAN"
     },
@@ -651,6 +678,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(225, 139, 150)",
+      "deprecated": true,
       "originalValue": "{!HILLIER}",
       "name": "COLOR_HILLIER"
     },
@@ -658,6 +686,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(109, 159, 235)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "COLOR_SKY_BLUE_TINT_01"
     },
@@ -665,6 +694,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(157, 192, 242)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_02}",
       "name": "COLOR_SKY_BLUE_TINT_02"
     },
@@ -672,6 +702,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 123, 89)",
+      "deprecated": true,
       "originalValue": "{!BUNOL}",
       "name": "COLOR_BUNOL"
     },
@@ -679,6 +710,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(205, 223, 248)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_03}",
       "name": "COLOR_SKY_BLUE_TINT_03"
     },
@@ -686,6 +718,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(17, 18, 54)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "COLOR_SKY_GRAY"
     },
@@ -693,6 +726,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 231, 224)",
+      "deprecated": true,
       "originalValue": "{!NARA}",
       "name": "COLOR_NARA"
     },
@@ -700,6 +734,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(8, 78, 178)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_01}",
       "name": "COLOR_SKY_BLUE_SHADE_01"
     },
@@ -707,6 +742,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(4, 39, 89)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_SHADE_02}",
       "name": "COLOR_SKY_BLUE_SHADE_02"
     },
@@ -959,6 +995,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "TEXT_PRIMARY_DARK_COLOR"
     },
@@ -973,6 +1010,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(142, 142, 147)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_QUATERNARY_DARK_COLOR"
     },
@@ -987,6 +1025,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(143, 144, 160)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_QUATERNARY_LIGHT_COLOR"
     },
@@ -1001,6 +1040,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(17, 18, 54)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY}",
       "name": "TEXT_PRIMARY_LIGHT_COLOR"
     },
@@ -1029,6 +1069,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(142, 142, 147)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_TERTIARY_DARK_COLOR"
     },
@@ -1036,6 +1077,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(178, 178, 191)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "TEXT_SECONDARY_DARK_COLOR"
     },
@@ -1065,6 +1107,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(104, 105, 127)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "TEXT_SECONDARY_LIGHT_COLOR"
     },
@@ -1079,6 +1122,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(143, 144, 160)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_TERTIARY_LIGHT_COLOR"
     },
@@ -1100,6 +1144,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(58, 58, 60)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_03}",
       "name": "BACKGROUND_ELEVATION_03_DARK_COLOR"
     },
@@ -1107,6 +1152,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(44, 44, 46)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_ELEVATION_02_DARK_COLOR"
     },
@@ -1114,6 +1160,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(72, 72, 74)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_04}",
       "name": "LINE_DARK_COLOR"
     },
@@ -1121,6 +1168,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(29, 27, 32)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ELEVATION_01_DARK_COLOR"
     },
@@ -1128,6 +1176,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(29, 27, 32)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_DARK_COLOR"
     },
@@ -1135,6 +1184,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_LIGHT_COLOR"
     },
@@ -1142,6 +1192,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 0, 0)",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_DARK_COLOR"
     },
@@ -1149,6 +1200,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ALTERNATIVE_SECONDARY_LIGHT_COLOR"
     },
@@ -1163,6 +1215,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 166, 152)",
+      "deprecated": true,
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_SYSTEM_GREEN"
     },
@@ -1170,6 +1223,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_01_LIGHT_COLOR"
     },
@@ -1177,6 +1231,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(205, 205, 215)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "LINE_LIGHT_COLOR"
     },
@@ -1184,6 +1239,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_02_LIGHT_COLOR"
     },
@@ -1198,6 +1254,7 @@
       "type": "color",
       "category": "text-colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_ELEVATION_03_LIGHT_COLOR"
     },
@@ -1205,6 +1262,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(44, 44, 46)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_02}",
       "name": "BACKGROUND_TERTIARY_DARK_COLOR"
     },
@@ -1212,6 +1270,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(29, 27, 32)",
+      "deprecated": true,
       "originalValue": "{!BLACK_TINT_01}",
       "name": "BACKGROUND_SECONDARY_DARK_COLOR"
     },
@@ -1219,6 +1278,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(241, 242, 248)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_ALTERNATIVE_LIGHT_COLOR"
     },
@@ -1226,6 +1286,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(109, 159, 235)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "PRIMARY_DARK_COLOR"
     },
@@ -1233,6 +1294,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(209, 67, 91)",
+      "deprecated": true,
       "originalValue": "{!PANJIN}",
       "name": "COLOR_SYSTEM_RED"
     },
@@ -1240,6 +1302,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(0, 0, 0)",
+      "deprecated": true,
       "originalValue": "{!BLACK}",
       "name": "BACKGROUND_ALTERNATIVE_DARK_COLOR"
     },
@@ -1247,6 +1310,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(7, 112, 227)",
+      "deprecated": true,
       "originalValue": "{!SKY_BLUE}",
       "name": "PRIMARY_LIGHT_COLOR"
     },
@@ -1254,6 +1318,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(255, 255, 255)",
+      "deprecated": true,
       "originalValue": "{!WHITE}",
       "name": "BACKGROUND_TERTIARY_LIGHT_COLOR"
     },
@@ -1261,6 +1326,7 @@
       "type": "color",
       "category": "colors",
       "value": "rgb(241, 242, 248)",
+      "deprecated": true,
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "BACKGROUND_SECONDARY_LIGHT_COLOR"
     },


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

This PR deprecates all the colours from the old system.

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
