### PR TITLE
[NO JIRA]: Fork colours for web to keep old styles for refresh

### DIFF
--- a/packages/bpk-foundations-web/src/base/aliases.json
+++ b/packages/bpk-foundations-web/src/base/aliases.json
@@ -1,7 +1,7 @@
 {
   "imports": [
     "@skyscanner/bpk-foundations-common/base/animations.json",
-    "@skyscanner/bpk-foundations-common/base/colors.json"
+    "./fork/colors.json"
   ],
   "aliases": {
     "BUTTON_FONT_SIZE": "1.1875rem",

--- a/packages/bpk-foundations-web/src/base/fork/colors.json
+++ b/packages/bpk-foundations-web/src/base/fork/colors.json
@@ -1,0 +1,442 @@
+{
+  "imports": [
+    "@skyscanner/bpk-foundations-common/base/colors.json"
+  ],
+  "aliases": {
+    "MONTEVERDE": "#00a698",
+    "GLENCOE": "#73cec6",
+    "SAGANO": "#d0eeec",
+    "KOLKATA": "#ff9400",
+    "ERFOUD": "#ffb54d",
+    "BAGAN": "#ffebd0",
+    "BUNOL": "#ff7b59",
+    "PETRA": "#ffab95",
+    "NARA": "#ffe7e0",
+    "ABISKO": "#5a489b",
+    "VALENSOLE": "#a59bc8",
+    "TOCHIGI": "#e1ddec",
+    "PANJIN": "#d1435b",
+    "HILLIER": "#e18b96",
+    "HARBOUR": "#f6dde1",
+    "SKY_BLUE_SHADE_03": "#02122c",
+    "SKY_BLUE_SHADE_02": "#042759",
+    "SKY_BLUE_SHADE_01": "#084eb2",
+    "SKY_BLUE_TINT_01": "#6d9feb",
+    "SKY_BLUE_TINT_02": "#9dc0f2",
+    "SKY_BLUE_TINT_03": "#cddff8",
+    "SKY_GRAY_TINT_07": "#F1F2F8",
+    "SKY_GRAY_TINT_06": "#DDDDE5",
+    "SKY_GRAY_TINT_05": "#CDCDD7",
+    "SKY_GRAY_TINT_04": "#B2B2BF",
+    "SKY_GRAY_TINT_03": "#8f90a0",
+    "SKY_GRAY_TINT_02": "#68697F",
+    "SKY_GRAY_TINT_01": "#444560",
+    "SKY_GRAY": "#111236",
+    "BLACK": "#000000",
+    "BLACK_TINT_01": "#1D1B20",
+    "BLACK_TINT_02": "#2C2C2E",
+    "BLACK_TINT_03": "#3A3A3C",
+    "BLACK_TINT_04": "#48484A",
+    "BLACK_TINT_05": "#636366",
+    "BLACK_TINT_06": "#8E8E93",
+    "PRIMARY_GRADIENT_LIGHT": "#02DDD8"
+  },
+  "props": {
+    "COLOR_MONTEVERDE": {
+      "value": "{!MONTEVERDE}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_GLENCOE": {
+      "value": "{!GLENCOE}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SAGANO": {
+      "value": "{!SAGANO}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_KOLKATA": {
+      "value": "{!KOLKATA}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_ERFOUD": {
+      "value": "{!ERFOUD}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_BAGAN": {
+      "value": "{!BAGAN}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_BUNOL": {
+      "value": "{!BUNOL}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_PETRA": {
+      "value": "{!PETRA}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_NARA": {
+      "value": "{!NARA}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_ABISKO": {
+      "value": "{!ABISKO}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_VALENSOLE": {
+      "value": "{!VALENSOLE}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_TOCHIGI": {
+      "value": "{!TOCHIGI}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_PANJIN": {
+      "value": "{!PANJIN}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_HILLIER": {
+      "value": "{!HILLIER}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_HARBOUR": {
+      "value": "{!HARBOUR}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_BLUE_SHADE_03": {
+      "value": "{!SKY_BLUE_SHADE_03}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_BLUE_SHADE_02": {
+      "value": "{!SKY_BLUE_SHADE_02}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_BLUE_SHADE_01": {
+      "value": "{!SKY_BLUE_SHADE_01}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_BLUE_TINT_01": {
+      "value": "{!SKY_BLUE_TINT_01}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_BLUE_TINT_02": {
+      "value": "{!SKY_BLUE_TINT_02}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_BLUE_TINT_03": {
+      "value": "{!SKY_BLUE_TINT_03}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_GRAY_TINT_07": {
+      "value": "{!SKY_GRAY_TINT_07}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_GRAY_TINT_06": {
+      "value": "{!SKY_GRAY_TINT_06}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_GRAY_TINT_05": {
+      "value": "{!SKY_GRAY_TINT_05}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_GRAY_TINT_04": {
+      "value": "{!SKY_GRAY_TINT_04}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_GRAY_TINT_03": {
+      "value": "{!SKY_GRAY_TINT_03}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_GRAY_TINT_02": {
+      "value": "{!SKY_GRAY_TINT_02}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_GRAY_TINT_01": {
+      "value": "{!SKY_GRAY_TINT_01}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SKY_GRAY": {
+      "value": "{!SKY_GRAY}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_PRIMARY_GRADIENT_LIGHT": {
+      "value": "{!SKY_BLUE}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_BLACK_TINT_01": {
+      "value": "{!BLACK_TINT_01}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_BLACK_TINT_02": {
+      "value": "{!BLACK_TINT_02}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_BLACK_TINT_03": {
+      "value": "{!BLACK_TINT_03}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_BLACK_TINT_04": {
+      "value": "{!BLACK_TINT_04}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_BLACK_TINT_05": {
+      "value": "{!BLACK_TINT_05}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_BLACK_TINT_06": {
+      "value": "{!BLACK_TINT_06}",
+      "deprecated": true,
+      "type": "color",
+      "category": "colors"
+    },
+    "COLOR_SYSTEM_RED": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!PANJIN}",
+      "deprecated": true
+    },
+    "COLOR_SYSTEM_GREEN": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!MONTEVERDE}",
+      "deprecated": true
+    },
+    "LINE_LIGHT_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!SKY_GRAY_TINT_05}",
+      "deprecated": true
+    },
+    "LINE_DARK_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!BLACK_TINT_04}",
+      "deprecated": true
+    },
+    "PRIMARY_LIGHT_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!SKY_BLUE}",
+      "deprecated": true
+    },
+    "PRIMARY_DARK_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!SKY_BLUE_TINT_01}",
+      "deprecated": true
+    },
+    "BACKGROUND_LIGHT_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!WHITE}",
+      "deprecated": true
+    },
+    "BACKGROUND_DARK_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!BLACK}",
+      "deprecated": true
+    },
+    "BACKGROUND_ALTERNATIVE_LIGHT_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!SKY_GRAY_TINT_07}",
+      "deprecated": true
+    },
+    "BACKGROUND_ALTERNATIVE_DARK_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!BLACK}",
+      "deprecated": true
+    },
+    "BACKGROUND_SECONDARY_LIGHT_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!SKY_GRAY_TINT_07}",
+      "deprecated": true
+    },
+    "BACKGROUND_SECONDARY_DARK_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!BLACK_TINT_01}",
+      "deprecated": true
+    },
+    "BACKGROUND_ALTERNATIVE_SECONDARY_LIGHT_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!WHITE}",
+      "deprecated": true
+    },
+    "BACKGROUND_ALTERNATIVE_SECONDARY_DARK_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!BLACK_TINT_01}",
+      "deprecated": true
+    },
+    "BACKGROUND_TERTIARY_LIGHT_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!WHITE}",
+      "deprecated": true
+    },
+    "BACKGROUND_TERTIARY_DARK_COLOR": {
+      "type": "color",
+      "category": "colors",
+      "value": "{!BLACK_TINT_02}",
+      "deprecated": true
+    },
+    "BACKGROUND_ELEVATION_01_LIGHT_COLOR": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "{!WHITE}",
+      "deprecated": true
+    },
+    "BACKGROUND_ELEVATION_01_DARK_COLOR": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "{!BLACK_TINT_01}",
+      "deprecated": true
+    },
+    "BACKGROUND_ELEVATION_02_LIGHT_COLOR": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "{!WHITE}",
+      "deprecated": true
+    },
+    "BACKGROUND_ELEVATION_02_DARK_COLOR": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "{!BLACK_TINT_02}",
+      "deprecated": true
+    },
+    "BACKGROUND_ELEVATION_03_LIGHT_COLOR": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "{!WHITE}",
+      "deprecated": true
+    },
+    "BACKGROUND_ELEVATION_03_DARK_COLOR": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "{!BLACK_TINT_03}",
+      "deprecated": true
+    },
+    "TEXT_PRIMARY_LIGHT_COLOR": {
+      "value": "{!SKY_GRAY}",
+      "deprecated": true,
+      "type": "color",
+      "category": "text-colors"
+    },
+    "TEXT_SECONDARY_LIGHT_COLOR": {
+      "value": "{!SKY_GRAY_TINT_02}",
+      "deprecated": true,
+      "type": "color",
+      "category": "text-colors"
+    },
+    "TEXT_TERTIARY_LIGHT_COLOR": {
+      "value": "{!SKY_GRAY_TINT_03}",
+      "deprecated": true,
+      "type": "color",
+      "category": "text-colors"
+    },
+    "TEXT_QUATERNARY_LIGHT_COLOR": {
+      "value": "{!SKY_GRAY_TINT_03}",
+      "deprecated": true,
+      "type": "color",
+      "category": "text-colors"
+    },
+    "TEXT_PRIMARY_DARK_COLOR": {
+      "value": "{!WHITE}",
+      "deprecated": true,
+      "type": "color",
+      "category": "text-colors"
+    },
+    "TEXT_SECONDARY_DARK_COLOR": {
+      "value": "{!SKY_GRAY_TINT_04}",
+      "deprecated": true,
+      "type": "color",
+      "category": "text-colors"
+    },
+    "TEXT_TERTIARY_DARK_COLOR": {
+      "value": "{!BLACK_TINT_06}",
+      "deprecated": true,
+      "type": "color",
+      "category": "text-colors"
+    },
+    "TEXT_QUATERNARY_DARK_COLOR": {
+      "value": "{!BLACK_TINT_06}",
+      "deprecated": true,
+      "type": "color",
+      "category": "text-colors"
+    }
+  }
+}

--- a/packages/bpk-foundations-web/tokens/base.raw.json
+++ b/packages/bpk-foundations-web/tokens/base.raw.json
@@ -459,50 +459,50 @@
       "name": "DURATION_BASE"
     },
     "COLOR_SKY_BLUE_SHADE_03": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(2, 18, 44)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_SHADE_03}",
       "name": "COLOR_SKY_BLUE_SHADE_03"
     },
     "COLOR_PRIMARY_GRADIENT_LIGHT": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(7, 112, 227)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE}",
       "name": "COLOR_PRIMARY_GRADIENT_LIGHT"
     },
     "COLOR_ERFOUD": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 181, 77)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!ERFOUD}",
       "name": "COLOR_ERFOUD"
     },
     "COLOR_VALENSOLE": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(165, 155, 200)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!VALENSOLE}",
       "name": "COLOR_VALENSOLE"
     },
     "COLOR_MONTEVERDE": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(0, 166, 152)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_MONTEVERDE"
     },
     "COLOR_SKY_GRAY_TINT_01": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(68, 69, 96)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_01}",
       "name": "COLOR_SKY_GRAY_TINT_01"
     },
@@ -514,106 +514,106 @@
       "name": "COLOR_BLACK"
     },
     "COLOR_SKY_GRAY_TINT_02": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(104, 105, 127)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "COLOR_SKY_GRAY_TINT_02"
     },
     "COLOR_SAGANO": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(208, 238, 236)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SAGANO}",
       "name": "COLOR_SAGANO"
     },
     "COLOR_SKY_GRAY_TINT_03": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(143, 144, 160)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "COLOR_SKY_GRAY_TINT_03"
     },
     "COLOR_SKY_GRAY_TINT_04": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(178, 178, 191)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "COLOR_SKY_GRAY_TINT_04"
     },
     "COLOR_HARBOUR": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(246, 221, 225)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!HARBOUR}",
       "name": "COLOR_HARBOUR"
     },
     "COLOR_SKY_GRAY_TINT_05": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(205, 205, 215)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "COLOR_SKY_GRAY_TINT_05"
     },
     "COLOR_SKY_GRAY_TINT_06": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(221, 221, 229)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_06}",
       "name": "COLOR_SKY_GRAY_TINT_06"
     },
     "COLOR_BLACK_TINT_01": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(29, 27, 32)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_01}",
       "name": "COLOR_BLACK_TINT_01"
     },
     "COLOR_SKY_GRAY_TINT_07": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(241, 242, 248)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "COLOR_SKY_GRAY_TINT_07"
     },
     "COLOR_BLACK_TINT_02": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(44, 44, 46)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_02}",
       "name": "COLOR_BLACK_TINT_02"
     },
     "COLOR_ABISKO": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(90, 72, 155)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!ABISKO}",
       "name": "COLOR_ABISKO"
     },
     "COLOR_BLACK_TINT_03": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(58, 58, 60)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_03}",
       "name": "COLOR_BLACK_TINT_03"
     },
     "COLOR_BLACK_TINT_04": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(72, 72, 74)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_04}",
       "name": "COLOR_BLACK_TINT_04"
     },
@@ -625,58 +625,58 @@
       "name": "COLOR_WHITE"
     },
     "COLOR_BLACK_TINT_05": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(99, 99, 102)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_05}",
       "name": "COLOR_BLACK_TINT_05"
     },
     "COLOR_BLACK_TINT_06": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(142, 142, 147)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_06}",
       "name": "COLOR_BLACK_TINT_06"
     },
     "COLOR_PANJIN": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(209, 67, 91)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!PANJIN}",
       "name": "COLOR_PANJIN"
     },
     "COLOR_KOLKATA": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 148, 0)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!KOLKATA}",
       "name": "COLOR_KOLKATA"
     },
     "COLOR_GLENCOE": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(115, 206, 198)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!GLENCOE}",
       "name": "COLOR_GLENCOE"
     },
     "COLOR_TOCHIGI": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(225, 221, 236)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!TOCHIGI}",
       "name": "COLOR_TOCHIGI"
     },
     "COLOR_PETRA": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 171, 149)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!PETRA}",
       "name": "COLOR_PETRA"
     },
@@ -688,82 +688,82 @@
       "name": "COLOR_SKY_BLUE"
     },
     "COLOR_BAGAN": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 235, 208)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BAGAN}",
       "name": "COLOR_BAGAN"
     },
     "COLOR_HILLIER": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(225, 139, 150)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!HILLIER}",
       "name": "COLOR_HILLIER"
     },
     "COLOR_SKY_BLUE_TINT_01": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(109, 159, 235)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "COLOR_SKY_BLUE_TINT_01"
     },
     "COLOR_SKY_BLUE_TINT_02": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(157, 192, 242)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_TINT_02}",
       "name": "COLOR_SKY_BLUE_TINT_02"
     },
     "COLOR_BUNOL": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 123, 89)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BUNOL}",
       "name": "COLOR_BUNOL"
     },
     "COLOR_SKY_BLUE_TINT_03": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(205, 223, 248)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_TINT_03}",
       "name": "COLOR_SKY_BLUE_TINT_03"
     },
     "COLOR_SKY_GRAY": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(17, 18, 54)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY}",
       "name": "COLOR_SKY_GRAY"
     },
     "COLOR_NARA": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 231, 224)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!NARA}",
       "name": "COLOR_NARA"
     },
     "COLOR_SKY_BLUE_SHADE_01": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(8, 78, 178)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_SHADE_01}",
       "name": "COLOR_SKY_BLUE_SHADE_01"
     },
     "COLOR_SKY_BLUE_SHADE_02": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(4, 39, 89)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_SHADE_02}",
       "name": "COLOR_SKY_BLUE_SHADE_02"
     },
@@ -1013,10 +1013,10 @@
       "name": "TEXT_DISABLED_NIGHT"
     },
     "TEXT_PRIMARY_DARK_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(255, 255, 255)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!WHITE}",
       "name": "TEXT_PRIMARY_DARK_COLOR"
     },
@@ -1028,10 +1028,10 @@
       "name": "TEXT_LINK_DAY"
     },
     "TEXT_QUATERNARY_DARK_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(142, 142, 147)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_QUATERNARY_DARK_COLOR"
     },
@@ -1043,10 +1043,10 @@
       "name": "TEXT_PRIMARY_NIGHT"
     },
     "TEXT_QUATERNARY_LIGHT_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(143, 144, 160)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_QUATERNARY_LIGHT_COLOR"
     },
@@ -1058,10 +1058,10 @@
       "name": "TEXT_DISABLED_DAY"
     },
     "TEXT_PRIMARY_LIGHT_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(17, 18, 54)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!SKY_GRAY}",
       "name": "TEXT_PRIMARY_LIGHT_COLOR"
     },
@@ -1087,18 +1087,18 @@
       "name": "TEXT_ERROR_DAY"
     },
     "TEXT_TERTIARY_DARK_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(142, 142, 147)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_TERTIARY_DARK_COLOR"
     },
     "TEXT_SECONDARY_DARK_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(178, 178, 191)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "TEXT_SECONDARY_DARK_COLOR"
     },
@@ -1125,10 +1125,10 @@
       "name": "TEXT_ON_DARK_NIGHT"
     },
     "TEXT_SECONDARY_LIGHT_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(104, 105, 127)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "TEXT_SECONDARY_LIGHT_COLOR"
     },
@@ -1140,10 +1140,10 @@
       "name": "TEXT_PRIMARY_INVERSE_DAY"
     },
     "TEXT_TERTIARY_LIGHT_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(143, 144, 160)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_TERTIARY_LIGHT_COLOR"
     },

--- a/packages/bpk-foundations-web/tokens/breakpoints.raw.json
+++ b/packages/bpk-foundations-web/tokens/breakpoints.raw.json
@@ -438,50 +438,50 @@
   },
   "props": {
     "COLOR_SKY_BLUE_SHADE_03": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(2, 18, 44)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_SHADE_03}",
       "name": "COLOR_SKY_BLUE_SHADE_03"
     },
     "COLOR_PRIMARY_GRADIENT_LIGHT": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(7, 112, 227)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE}",
       "name": "COLOR_PRIMARY_GRADIENT_LIGHT"
     },
     "COLOR_ERFOUD": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 181, 77)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!ERFOUD}",
       "name": "COLOR_ERFOUD"
     },
     "COLOR_VALENSOLE": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(165, 155, 200)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!VALENSOLE}",
       "name": "COLOR_VALENSOLE"
     },
     "COLOR_MONTEVERDE": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(0, 166, 152)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!MONTEVERDE}",
       "name": "COLOR_MONTEVERDE"
     },
     "COLOR_SKY_GRAY_TINT_01": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(68, 69, 96)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_01}",
       "name": "COLOR_SKY_GRAY_TINT_01"
     },
@@ -493,106 +493,106 @@
       "name": "COLOR_BLACK"
     },
     "COLOR_SKY_GRAY_TINT_02": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(104, 105, 127)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "COLOR_SKY_GRAY_TINT_02"
     },
     "COLOR_SAGANO": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(208, 238, 236)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SAGANO}",
       "name": "COLOR_SAGANO"
     },
     "COLOR_SKY_GRAY_TINT_03": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(143, 144, 160)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "COLOR_SKY_GRAY_TINT_03"
     },
     "COLOR_SKY_GRAY_TINT_04": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(178, 178, 191)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "COLOR_SKY_GRAY_TINT_04"
     },
     "COLOR_HARBOUR": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(246, 221, 225)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!HARBOUR}",
       "name": "COLOR_HARBOUR"
     },
     "COLOR_SKY_GRAY_TINT_05": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(205, 205, 215)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_05}",
       "name": "COLOR_SKY_GRAY_TINT_05"
     },
     "COLOR_SKY_GRAY_TINT_06": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(221, 221, 229)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_06}",
       "name": "COLOR_SKY_GRAY_TINT_06"
     },
     "COLOR_BLACK_TINT_01": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(29, 27, 32)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_01}",
       "name": "COLOR_BLACK_TINT_01"
     },
     "COLOR_SKY_GRAY_TINT_07": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(241, 242, 248)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY_TINT_07}",
       "name": "COLOR_SKY_GRAY_TINT_07"
     },
     "COLOR_BLACK_TINT_02": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(44, 44, 46)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_02}",
       "name": "COLOR_BLACK_TINT_02"
     },
     "COLOR_ABISKO": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(90, 72, 155)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!ABISKO}",
       "name": "COLOR_ABISKO"
     },
     "COLOR_BLACK_TINT_03": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(58, 58, 60)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_03}",
       "name": "COLOR_BLACK_TINT_03"
     },
     "COLOR_BLACK_TINT_04": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(72, 72, 74)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_04}",
       "name": "COLOR_BLACK_TINT_04"
     },
@@ -604,58 +604,58 @@
       "name": "COLOR_WHITE"
     },
     "COLOR_BLACK_TINT_05": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(99, 99, 102)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_05}",
       "name": "COLOR_BLACK_TINT_05"
     },
     "COLOR_BLACK_TINT_06": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(142, 142, 147)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BLACK_TINT_06}",
       "name": "COLOR_BLACK_TINT_06"
     },
     "COLOR_PANJIN": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(209, 67, 91)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!PANJIN}",
       "name": "COLOR_PANJIN"
     },
     "COLOR_KOLKATA": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 148, 0)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!KOLKATA}",
       "name": "COLOR_KOLKATA"
     },
     "COLOR_GLENCOE": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(115, 206, 198)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!GLENCOE}",
       "name": "COLOR_GLENCOE"
     },
     "COLOR_TOCHIGI": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(225, 221, 236)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!TOCHIGI}",
       "name": "COLOR_TOCHIGI"
     },
     "COLOR_PETRA": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 171, 149)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!PETRA}",
       "name": "COLOR_PETRA"
     },
@@ -667,82 +667,82 @@
       "name": "COLOR_SKY_BLUE"
     },
     "COLOR_BAGAN": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 235, 208)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BAGAN}",
       "name": "COLOR_BAGAN"
     },
     "COLOR_HILLIER": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(225, 139, 150)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!HILLIER}",
       "name": "COLOR_HILLIER"
     },
     "COLOR_SKY_BLUE_TINT_01": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(109, 159, 235)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_TINT_01}",
       "name": "COLOR_SKY_BLUE_TINT_01"
     },
     "COLOR_SKY_BLUE_TINT_02": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(157, 192, 242)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_TINT_02}",
       "name": "COLOR_SKY_BLUE_TINT_02"
     },
     "COLOR_BUNOL": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 123, 89)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!BUNOL}",
       "name": "COLOR_BUNOL"
     },
     "COLOR_SKY_BLUE_TINT_03": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(205, 223, 248)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_TINT_03}",
       "name": "COLOR_SKY_BLUE_TINT_03"
     },
     "COLOR_SKY_GRAY": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(17, 18, 54)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_GRAY}",
       "name": "COLOR_SKY_GRAY"
     },
     "COLOR_NARA": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(255, 231, 224)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!NARA}",
       "name": "COLOR_NARA"
     },
     "COLOR_SKY_BLUE_SHADE_01": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(8, 78, 178)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_SHADE_01}",
       "name": "COLOR_SKY_BLUE_SHADE_01"
     },
     "COLOR_SKY_BLUE_SHADE_02": {
-      "type": "color",
-      "category": "colors",
       "value": "rgb(4, 39, 89)",
       "deprecated": true,
+      "type": "color",
+      "category": "colors",
       "originalValue": "{!SKY_BLUE_SHADE_02}",
       "name": "COLOR_SKY_BLUE_SHADE_02"
     },
@@ -992,10 +992,10 @@
       "name": "TEXT_DISABLED_NIGHT"
     },
     "TEXT_PRIMARY_DARK_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(255, 255, 255)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!WHITE}",
       "name": "TEXT_PRIMARY_DARK_COLOR"
     },
@@ -1007,10 +1007,10 @@
       "name": "TEXT_LINK_DAY"
     },
     "TEXT_QUATERNARY_DARK_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(142, 142, 147)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_QUATERNARY_DARK_COLOR"
     },
@@ -1022,10 +1022,10 @@
       "name": "TEXT_PRIMARY_NIGHT"
     },
     "TEXT_QUATERNARY_LIGHT_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(143, 144, 160)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_QUATERNARY_LIGHT_COLOR"
     },
@@ -1037,10 +1037,10 @@
       "name": "TEXT_DISABLED_DAY"
     },
     "TEXT_PRIMARY_LIGHT_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(17, 18, 54)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!SKY_GRAY}",
       "name": "TEXT_PRIMARY_LIGHT_COLOR"
     },
@@ -1066,18 +1066,18 @@
       "name": "TEXT_ERROR_DAY"
     },
     "TEXT_TERTIARY_DARK_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(142, 142, 147)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!BLACK_TINT_06}",
       "name": "TEXT_TERTIARY_DARK_COLOR"
     },
     "TEXT_SECONDARY_DARK_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(178, 178, 191)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!SKY_GRAY_TINT_04}",
       "name": "TEXT_SECONDARY_DARK_COLOR"
     },
@@ -1104,10 +1104,10 @@
       "name": "TEXT_ON_DARK_NIGHT"
     },
     "TEXT_SECONDARY_LIGHT_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(104, 105, 127)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!SKY_GRAY_TINT_02}",
       "name": "TEXT_SECONDARY_LIGHT_COLOR"
     },
@@ -1119,10 +1119,10 @@
       "name": "TEXT_PRIMARY_INVERSE_DAY"
     },
     "TEXT_TERTIARY_LIGHT_COLOR": {
-      "type": "color",
-      "category": "text-colors",
       "value": "rgb(143, 144, 160)",
       "deprecated": true,
+      "type": "color",
+      "category": "text-colors",
       "originalValue": "{!SKY_GRAY_TINT_03}",
       "name": "TEXT_TERTIARY_LIGHT_COLOR"
     },


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

As part of the new colours rollout, for Web we want to keep our old colours alongside our new colours compared to apps who will change both old and new to the new colours.

So in order to accomodate this we are temporarily 'forking' the colours to keep both sets active as our web teams adopt them

Remember to include the following changes:

~- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))~ Not required as this is an internal change and not affect on the current colours/implementation
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
