### PR TITLE
[NO JIRA]: Fix file naming issue from a recent linting upgrade

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,3 +2,6 @@
 
 - @skyscanner/bpk-svgs:
     - Bump `gulp-svgmin` to latest version to fix broken icons
+
+- @skyscanner/bpk-mixins:
+    - Fix incorrect import of `_bonds.scss`

--- a/packages/bpk-mixins/src/mixins/_borders.scss
+++ b/packages/bpk-mixins/src/mixins/_borders.scss
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-@import '../bonds.scss.scss';
+@import '../bonds.scss';
 
 ////
 /// @group borders


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

A recent change in linting upgrade, there was an issue introduced that changed an import to include a double extension by accident which causes build errors as its not a valid file.

This fixes it

Remember to include the following changes:

- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
