### PR TITLE
[NO JIRA]: Reverting recent stylelint changes

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Fixed:**
+	- bpk-svgs:
+		- Further reverting of recent stylelint changes as some new rules are suggesting things we don't currently support.

--- a/packages/bpk-mixins/src/mixins/_grids.scss
+++ b/packages/bpk-mixins/src/mixins/_grids.scss
@@ -177,7 +177,10 @@
     display: none;
   } @else {
     display: block;
-    width: math.percentage($size / $bpk-grid-columns);
+
+    /* Disabling rule here as this method is for newer sass versions that we don't yet support */
+    /* stylelint-disable-next-line scss/no-global-function-names */
+    width: percentage($size / $bpk-grid-columns);
   }
 }
 
@@ -231,10 +234,14 @@
       margin-right: 0;
     }
   } @else {
-    margin-left: math.percentage($size / $bpk-grid-columns);
+    /* Disabling rule here as this method is for newer sass versions that we don't yet support */
+    /* stylelint-disable-next-line scss/no-global-function-names */
+    margin-left: percentage($size / $bpk-grid-columns);
 
     @include bpk-rtl {
-      margin-right: math.percentage($size / $bpk-grid-columns);
+      /* Disabling rule here as this method is for newer sass versions that we don't yet support */
+      /* stylelint-disable-next-line scss/no-global-function-names */
+      margin-right: percentage($size / $bpk-grid-columns);
       margin-left: 0;
     }
   }

--- a/packages/bpk-mixins/src/mixins/_svgs.scss
+++ b/packages/bpk-mixins/src/mixins/_svgs.scss
@@ -124,7 +124,10 @@
   }
 
   $icon-size: if($size == large, $bpk-icon-size-lg, $bpk-icon-size-sm);
-  $raw-svg: map.get($icon-map, $icon);
+
+  /* Disabling rule here as this method is for newer sass versions that we don't yet support */
+  /* stylelint-disable-next-line scss/no-global-function-names */
+  $raw-svg: map-get($icon-map, $icon);
   $svg-string: str-replace($raw-svg, '$$COLOR$$', $color);
   $datauri: 'data:image/svg+xml;base64,' + encodebase64($svg-string);
 

--- a/packages/bpk-mixins/src/mixins/_utils.scss
+++ b/packages/bpk-mixins/src/mixins/_utils.scss
@@ -207,7 +207,9 @@
 /// @param {string} $replace [''] - The string to replace $search.
 
 @function str-replace($string, $search, $replace: '') {
-  $index: string.index($string, $search);
+  /* Disabling rule here as the recommendation method is for newer sass versions that we don't yet support */
+  /* stylelint-disable-next-line scss/no-global-function-names */
+  $index: str-index($string, $search);
 
   @if $index {
     @return str-slice($string, 1, $index - 1) + $replace +


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Our recent stylelint upgrade recently made aggressive suggestions for functions from the newer sass versions that as a company we don't currently support.

This PR reverts and disables this so not to cause build errors in BRS whilst it still uses old `node-sass` instead of newer techniques 

Remember to include the following changes:

- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)
