### PR TITLE
[BD-6664] Update bpk-mixins input and textarea placeholder color

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,4 @@
+**Changed:**
+
+`bpk-mixins`
+  - Update placeholder color in `input` and `textarea` from `text-disabled` to `text-secondary`.

--- a/packages/bpk-mixins/src/mixins/_forms.scss
+++ b/packages/bpk-mixins/src/mixins/_forms.scss
@@ -43,7 +43,7 @@ $bpk-spacing-v2: true;
   appearance: none;
 
   &::placeholder {
-    color: $bpk-text-disabled-day;
+    color: $bpk-text-secondary-day;
   }
 
   &:disabled {
@@ -976,7 +976,7 @@ $bpk-spacing-v2: true;
   appearance: none;
 
   &::placeholder {
-    color: $bpk-text-disabled-day;
+    color: $bpk-text-secondary-day;
   }
 
   &:disabled {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->
##  Context
We have recived some [feedback](https://skyscanner.slack.com/archives/C03V4AJ8VQB/p1675840752294329) that the default color of placeholder in BpkInput looks pretty light-colored,  which might make the content unclearly. After [discuss](https://skyscanner.slack.com/archives/CUQ587E5D/p1675857743401299), decided make it darker, according the [figma](https://www.figma.com/file/irZ3YBx8vOm16ICkAr7mB3/Backpack?node-id=6353%3A6397&t=RMotY3araZaFAYDx-0), we update the placeholder color. 

## Change Description
 - Update placeholder color in `input` and `textarea` from `text-disabled` to `text-secondary`

### Screenshots
<!--- You could convert the video to gif to easy understand the change https://ezgif.com/video-to-gif --->

| Before                        | After                         |
| ----------------------------- | ----------------------------- |
| <img src="https://user-images.githubusercontent.com/33623220/218014277-50dc614f-773e-4716-995a-da1287617608.png" width=400/> | <img src="https://user-images.githubusercontent.com/33623220/218011958-a5f5aa9b-7ad1-40c2-a20f-08ce99e7b88a.png" width=400 /> |



Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated for changes to tokens, mixins, icons
