### PR TITLE
Add private token for Sponsored Banner

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,2 @@
+- `@skyscanner/bpk-foundations-common:`
+    - Added private tokens for sponsored banner

--- a/packages/bpk-foundations-android/package-lock.json
+++ b/packages/bpk-foundations-android/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@skyscanner/bpk-foundations-android",
-			"version": "7.2.0",
+			"version": "7.3.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"color": "^3.0.0"

--- a/packages/bpk-foundations-android/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-android/tokens/base.raw.android.json
@@ -3042,14 +3042,14 @@
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "originalValue": "{!GREY_10}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY"
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#243346ff",
       "originalValue": "{!NIGHT_GREY_25}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT"
@@ -4012,7 +4012,7 @@
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "originalValue": "{!GREY_10}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",

--- a/packages/bpk-foundations-android/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-android/tokens/base.raw.android.json
@@ -3040,6 +3040,20 @@
       "originalValue": "#00000033",
       "name": "PRIVATE_SKELETON_SHIMMER_CENTER_NIGHT"
     },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "originalValue": "{!GREY_10}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY"
+    },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#243346ff",
+      "originalValue": "{!NIGHT_GREY_25}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT"
+    },
     "ANIMATION_DURATION_XS": {
       "type": "duration",
       "value": "50ms",
@@ -3995,6 +4009,15 @@
       "name": "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
       "darkValue": "#00000033",
       "originalDarkValue": "#00000033"
+    },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "originalValue": "{!GREY_10}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",
+      "darkValue": "#243346ff",
+      "originalDarkValue": "{!NIGHT_GREY_25}"
     }
   },
   "propKeys": [
@@ -4354,6 +4377,8 @@
     "PRIVATE_SKELETON_SHIMMER_START_END_NIGHT",
     "PRIVATE_SKELETON_SHIMMER_CENTER_DAY",
     "PRIVATE_SKELETON_SHIMMER_CENTER_NIGHT",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT",
     "ANIMATION_DURATION_XS",
     "ANIMATION_DURATION_SM",
     "ANIMATION_DURATION_BASE",
@@ -4466,6 +4491,7 @@
     "PRIVATE_BUTTON_SECONDARY_ON_DARK_DISABLED_FOREGROUND_COLOR",
     "PRIVATE_BUTTON_PRIMARY_ON_DARK_PRESSED_BACKGROUND_COLOR",
     "PRIVATE_SKELETON_SHIMMER_START_END_COLOR",
-    "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR"
+    "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR"
   ]
 }

--- a/packages/bpk-foundations-common/base/colors.json
+++ b/packages/bpk-foundations-common/base/colors.json
@@ -12,6 +12,6 @@
     "./colors/map-marker.json",
     "./colors/button.json",
     "./colors/skeleton.json",
-    "./colors/sponsoredbanner.json"
+    "./colors/sponsored-banner.json"
   ]
 }

--- a/packages/bpk-foundations-common/base/colors.json
+++ b/packages/bpk-foundations-common/base/colors.json
@@ -11,6 +11,7 @@
     "./colors/chip.json",
     "./colors/map-marker.json",
     "./colors/button.json",
-    "./colors/skeleton.json"
+    "./colors/skeleton.json",
+    "./colors/sponsoredbanner.json"
   ]
 }

--- a/packages/bpk-foundations-common/base/colors/sponsored-banner.json
+++ b/packages/bpk-foundations-common/base/colors/sponsored-banner.json
@@ -2,7 +2,7 @@
     "imports": ["./aliases.json"],
     "global": {
         "type": "color",
-        "category": "sponsoredbanner-colors"
+        "category": "sponsored-banner-colors"
     },
     "props": {
         "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {

--- a/packages/bpk-foundations-common/base/colors/sponsoredbanner.json
+++ b/packages/bpk-foundations-common/base/colors/sponsoredbanner.json
@@ -1,0 +1,15 @@
+{
+    "imports": ["./aliases.json"],
+    "global": {
+        "type": "color",
+        "category": "sponsoredbanner-colors"
+    },
+    "props": {
+        "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {
+            "value": "{!GREY_10}"
+        },
+        "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT": {
+            "value": "{!NIGHT_GREY_25}"
+        }
+    }
+}

--- a/packages/bpk-foundations-common/package-lock.json
+++ b/packages/bpk-foundations-common/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@skyscanner/bpk-foundations-common",
-			"version": "6.2.0",
+			"version": "6.3.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"color": "^3.0.0"

--- a/packages/bpk-foundations-ios/package-lock.json
+++ b/packages/bpk-foundations-ios/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@skyscanner/bpk-foundations-ios",
-			"version": "6.2.0",
+			"version": "6.3.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"color": "^3.0.0"

--- a/packages/bpk-foundations-ios/tokens/base.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.ios.json
@@ -2611,14 +2611,14 @@
     },
     {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "originalValue": "{!GREY_10}",
       "name": "privateSponsoredBannerBackgroundDay"
     },
     {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#243346ff",
       "originalValue": "{!NIGHT_GREY_25}",
       "name": "privateSponsoredBannerBackgroundNight"
@@ -3785,7 +3785,7 @@
     },
     {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "originalValue": "{!GREY_10}",
       "name": "privateSponsoredBannerBackgroundColor",

--- a/packages/bpk-foundations-ios/tokens/base.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.ios.json
@@ -2610,6 +2610,20 @@
       "name": "privateSkeletonShimmerCenterNight"
     },
     {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "originalValue": "{!GREY_10}",
+      "name": "privateSponsoredBannerBackgroundDay"
+    },
+    {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#243346ff",
+      "originalValue": "{!NIGHT_GREY_25}",
+      "name": "privateSponsoredBannerBackgroundNight"
+    },
+    {
       "type": "duration",
       "value": "50ms",
       "category": "animations",
@@ -3768,6 +3782,15 @@
       "name": "privateSkeletonShimmerCenterColor",
       "darkValue": "#00000033",
       "originalDarkValue": "#00000033"
+    },
+    {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "originalValue": "{!GREY_10}",
+      "name": "privateSponsoredBannerBackgroundColor",
+      "darkValue": "#243346ff",
+      "originalDarkValue": "{!NIGHT_GREY_25}"
     }
   ]
 }

--- a/packages/bpk-foundations-ios/tokens/base.raw.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.raw.ios.json
@@ -3042,14 +3042,14 @@
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "originalValue": "{!GREY_10}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY"
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#243346ff",
       "originalValue": "{!NIGHT_GREY_25}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT"
@@ -4216,7 +4216,7 @@
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "originalValue": "{!GREY_10}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",

--- a/packages/bpk-foundations-ios/tokens/base.raw.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.raw.ios.json
@@ -3040,6 +3040,20 @@
       "originalValue": "#00000033",
       "name": "PRIVATE_SKELETON_SHIMMER_CENTER_NIGHT"
     },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "originalValue": "{!GREY_10}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY"
+    },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#243346ff",
+      "originalValue": "{!NIGHT_GREY_25}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT"
+    },
     "ANIMATION_DURATION_XS": {
       "type": "duration",
       "value": "50ms",
@@ -4199,6 +4213,15 @@
       "name": "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
       "darkValue": "#00000033",
       "originalDarkValue": "#00000033"
+    },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "originalValue": "{!GREY_10}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",
+      "darkValue": "#243346ff",
+      "originalDarkValue": "{!NIGHT_GREY_25}"
     }
   },
   "propKeys": [
@@ -4558,6 +4581,8 @@
     "PRIVATE_SKELETON_SHIMMER_START_END_NIGHT",
     "PRIVATE_SKELETON_SHIMMER_CENTER_DAY",
     "PRIVATE_SKELETON_SHIMMER_CENTER_NIGHT",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT",
     "ANIMATION_DURATION_XS",
     "ANIMATION_DURATION_SM",
     "ANIMATION_DURATION_BASE",
@@ -4699,6 +4724,7 @@
     "PRIVATE_BUTTON_SECONDARY_ON_DARK_DISABLED_FOREGROUND_COLOR",
     "PRIVATE_BUTTON_PRIMARY_ON_DARK_PRESSED_BACKGROUND_COLOR",
     "PRIVATE_SKELETON_SHIMMER_START_END_COLOR",
-    "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR"
+    "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR"
   ]
 }

--- a/packages/bpk-foundations-react-native/package-lock.json
+++ b/packages/bpk-foundations-react-native/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@skyscanner/bpk-foundations-react-native",
-			"version": "4.2.0",
+			"version": "4.3.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"color": "^3.0.0"

--- a/packages/bpk-foundations-react-native/tokens/android/base.react.native.common.js
+++ b/packages/bpk-foundations-react-native/tokens/android/base.react.native.common.js
@@ -237,6 +237,8 @@ module.exports = {
   privateSkeletonShimmerStartEndNight: "rgba(0, 0, 0, 0)",
   privateSkeletonShimmerCenterDay: "rgba(255, 255, 255, 0.6)",
   privateSkeletonShimmerCenterNight: "rgba(0, 0, 0, 0.2)",
+  privateSponsoredBannerBackgroundDay: "rgb(239, 241, 242)",
+  privateSponsoredBannerBackgroundNight: "rgb(36, 51, 70)",
   animationDurationXs: 50,
   animationDurationSm: 200,
   animationDurationBase: 400,

--- a/packages/bpk-foundations-react-native/tokens/android/base.react.native.es6.js
+++ b/packages/bpk-foundations-react-native/tokens/android/base.react.native.es6.js
@@ -236,6 +236,8 @@ export const privateSkeletonShimmerStartEndDay = "rgba(255, 255, 255, 0)";
 export const privateSkeletonShimmerStartEndNight = "rgba(0, 0, 0, 0)";
 export const privateSkeletonShimmerCenterDay = "rgba(255, 255, 255, 0.6)";
 export const privateSkeletonShimmerCenterNight = "rgba(0, 0, 0, 0.2)";
+export const privateSponsoredBannerBackgroundDay = "rgb(239, 241, 242)";
+export const privateSponsoredBannerBackgroundNight = "rgb(36, 51, 70)";
 export const animationDurationXs = 50;
 export const animationDurationSm = 200;
 export const animationDurationBase = 400;
@@ -819,6 +821,10 @@ spacingXxl,
 spacingNone,
 spacingIconText,
 };
+export const sponsoredbannerColors = {
+privateSponsoredBannerBackgroundDay,
+privateSponsoredBannerBackgroundNight,
+};
 export const statusColors = {
 statusSuccessSpotNight,
 statusSuccessFillNight,
@@ -984,3 +990,4 @@ export const privateButtonSecondaryOnDarkDisabledForegroundColor = undefined;
 export const privateButtonPrimaryOnDarkPressedBackgroundColor = undefined;
 export const privateSkeletonShimmerStartEndColor = undefined;
 export const privateSkeletonShimmerCenterColor = undefined;
+export const privateSponsoredBannerBackgroundColor = undefined;

--- a/packages/bpk-foundations-react-native/tokens/android/base.react.native.es6.js
+++ b/packages/bpk-foundations-react-native/tokens/android/base.react.native.es6.js
@@ -821,7 +821,7 @@ spacingXxl,
 spacingNone,
 spacingIconText,
 };
-export const sponsoredbannerColors = {
+export const sponsoredBannerColors = {
 privateSponsoredBannerBackgroundDay,
 privateSponsoredBannerBackgroundNight,
 };

--- a/packages/bpk-foundations-react-native/tokens/base.android.xml
+++ b/packages/bpk-foundations-react-native/tokens/base.android.xml
@@ -218,6 +218,8 @@
   <color name="PRIVATE_SKELETON_SHIMMER_START_END_NIGHT" category="skeleton-colors">#00000000</color>
   <color name="PRIVATE_SKELETON_SHIMMER_CENTER_DAY" category="skeleton-colors">#ffffff99</color>
   <color name="PRIVATE_SKELETON_SHIMMER_CENTER_NIGHT" category="skeleton-colors">#00000033</color>
+  <color name="PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY" category="sponsoredbanner-colors">#eff1f2ff</color>
+  <color name="PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT" category="sponsoredbanner-colors">#243346ff</color>
   <property name="ANIMATION_DURATION_XS" category="animations">50ms</property>
   <property name="ANIMATION_DURATION_SM" category="animations">200ms</property>
   <property name="ANIMATION_DURATION_BASE" category="animations">400ms</property>

--- a/packages/bpk-foundations-react-native/tokens/base.android.xml
+++ b/packages/bpk-foundations-react-native/tokens/base.android.xml
@@ -218,8 +218,8 @@
   <color name="PRIVATE_SKELETON_SHIMMER_START_END_NIGHT" category="skeleton-colors">#00000000</color>
   <color name="PRIVATE_SKELETON_SHIMMER_CENTER_DAY" category="skeleton-colors">#ffffff99</color>
   <color name="PRIVATE_SKELETON_SHIMMER_CENTER_NIGHT" category="skeleton-colors">#00000033</color>
-  <color name="PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY" category="sponsoredbanner-colors">#eff1f2ff</color>
-  <color name="PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT" category="sponsoredbanner-colors">#243346ff</color>
+  <color name="PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY" category="sponsored-banner-colors">#eff1f2ff</color>
+  <color name="PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT" category="sponsored-banner-colors">#243346ff</color>
   <property name="ANIMATION_DURATION_XS" category="animations">50ms</property>
   <property name="ANIMATION_DURATION_SM" category="animations">200ms</property>
   <property name="ANIMATION_DURATION_BASE" category="animations">400ms</property>

--- a/packages/bpk-foundations-react-native/tokens/base.ios.json
+++ b/packages/bpk-foundations-react-native/tokens/base.ios.json
@@ -1367,6 +1367,18 @@
       "name": "privateSkeletonShimmerCenterNight"
     },
     {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "name": "privateSponsoredBannerBackgroundDay"
+    },
+    {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#243346ff",
+      "name": "privateSponsoredBannerBackgroundNight"
+    },
+    {
       "type": "duration",
       "value": "50ms",
       "category": "animations",
@@ -2496,6 +2508,13 @@
       "value": "#ffffff99",
       "name": "privateSkeletonShimmerCenterColor",
       "darkValue": "#00000033"
+    },
+    {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "name": "privateSponsoredBannerBackgroundColor",
+      "darkValue": "#243346ff"
     }
   ]
 }

--- a/packages/bpk-foundations-react-native/tokens/base.ios.json
+++ b/packages/bpk-foundations-react-native/tokens/base.ios.json
@@ -1368,13 +1368,13 @@
     },
     {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "name": "privateSponsoredBannerBackgroundDay"
     },
     {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#243346ff",
       "name": "privateSponsoredBannerBackgroundNight"
     },
@@ -2511,7 +2511,7 @@
     },
     {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "name": "privateSponsoredBannerBackgroundColor",
       "darkValue": "#243346ff"

--- a/packages/bpk-foundations-react-native/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-react-native/tokens/base.raw.android.json
@@ -1991,6 +1991,20 @@
       "originalValue": "#00000033",
       "name": "PRIVATE_SKELETON_SHIMMER_CENTER_NIGHT"
     },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "originalValue": "{!GREY_10}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY"
+    },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#243346ff",
+      "originalValue": "{!NIGHT_GREY_25}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT"
+    },
     "ANIMATION_DURATION_XS": {
       "type": "duration",
       "value": "50ms",
@@ -3273,6 +3287,15 @@
       "name": "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
       "darkValue": "#00000033",
       "originalDarkValue": "#00000033"
+    },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "originalValue": "{!GREY_10}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",
+      "darkValue": "#243346ff",
+      "originalDarkValue": "{!NIGHT_GREY_25}"
     }
   },
   "propKeys": [
@@ -3494,6 +3517,8 @@
     "PRIVATE_SKELETON_SHIMMER_START_END_NIGHT",
     "PRIVATE_SKELETON_SHIMMER_CENTER_DAY",
     "PRIVATE_SKELETON_SHIMMER_CENTER_NIGHT",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT",
     "ANIMATION_DURATION_XS",
     "ANIMATION_DURATION_SM",
     "ANIMATION_DURATION_BASE",
@@ -3653,6 +3678,7 @@
     "PRIVATE_BUTTON_SECONDARY_ON_DARK_DISABLED_FOREGROUND_COLOR",
     "PRIVATE_BUTTON_PRIMARY_ON_DARK_PRESSED_BACKGROUND_COLOR",
     "PRIVATE_SKELETON_SHIMMER_START_END_COLOR",
-    "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR"
+    "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR"
   ]
 }

--- a/packages/bpk-foundations-react-native/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-react-native/tokens/base.raw.android.json
@@ -1993,14 +1993,14 @@
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "originalValue": "{!GREY_10}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY"
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#243346ff",
       "originalValue": "{!NIGHT_GREY_25}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT"
@@ -3290,7 +3290,7 @@
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "originalValue": "{!GREY_10}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",

--- a/packages/bpk-foundations-react-native/tokens/base.raw.ios.json
+++ b/packages/bpk-foundations-react-native/tokens/base.raw.ios.json
@@ -1970,6 +1970,20 @@
       "originalValue": "#00000033",
       "name": "PRIVATE_SKELETON_SHIMMER_CENTER_NIGHT"
     },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "originalValue": "{!GREY_10}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY"
+    },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#243346ff",
+      "originalValue": "{!NIGHT_GREY_25}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT"
+    },
     "ANIMATION_DURATION_XS": {
       "type": "duration",
       "value": "50ms",
@@ -3351,6 +3365,15 @@
       "name": "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
       "darkValue": "#00000033",
       "originalDarkValue": "#00000033"
+    },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "#eff1f2ff",
+      "originalValue": "{!GREY_10}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",
+      "darkValue": "#243346ff",
+      "originalDarkValue": "{!NIGHT_GREY_25}"
     }
   },
   "propKeys": [
@@ -3572,6 +3595,8 @@
     "PRIVATE_SKELETON_SHIMMER_START_END_NIGHT",
     "PRIVATE_SKELETON_SHIMMER_CENTER_DAY",
     "PRIVATE_SKELETON_SHIMMER_CENTER_NIGHT",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT",
     "ANIMATION_DURATION_XS",
     "ANIMATION_DURATION_SM",
     "ANIMATION_DURATION_BASE",
@@ -3745,6 +3770,7 @@
     "PRIVATE_BUTTON_SECONDARY_ON_DARK_DISABLED_FOREGROUND_COLOR",
     "PRIVATE_BUTTON_PRIMARY_ON_DARK_PRESSED_BACKGROUND_COLOR",
     "PRIVATE_SKELETON_SHIMMER_START_END_COLOR",
-    "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR"
+    "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR"
   ]
 }

--- a/packages/bpk-foundations-react-native/tokens/base.raw.ios.json
+++ b/packages/bpk-foundations-react-native/tokens/base.raw.ios.json
@@ -1972,14 +1972,14 @@
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "originalValue": "{!GREY_10}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY"
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#243346ff",
       "originalValue": "{!NIGHT_GREY_25}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT"
@@ -3368,7 +3368,7 @@
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "#eff1f2ff",
       "originalValue": "{!GREY_10}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",

--- a/packages/bpk-foundations-react-native/tokens/base.react.native.android.js
+++ b/packages/bpk-foundations-react-native/tokens/base.react.native.android.js
@@ -236,6 +236,8 @@ export const privateSkeletonShimmerStartEndDay = "rgba(255, 255, 255, 0)";
 export const privateSkeletonShimmerStartEndNight = "rgba(0, 0, 0, 0)";
 export const privateSkeletonShimmerCenterDay = "rgba(255, 255, 255, 0.6)";
 export const privateSkeletonShimmerCenterNight = "rgba(0, 0, 0, 0.2)";
+export const privateSponsoredBannerBackgroundDay = "rgb(239, 241, 242)";
+export const privateSponsoredBannerBackgroundNight = "rgb(36, 51, 70)";
 export const animationDurationXs = 50;
 export const animationDurationSm = 200;
 export const animationDurationBase = 400;
@@ -819,6 +821,10 @@ spacingXxl,
 spacingNone,
 spacingIconText,
 };
+export const sponsoredbannerColors = {
+privateSponsoredBannerBackgroundDay,
+privateSponsoredBannerBackgroundNight,
+};
 export const statusColors = {
 statusSuccessSpotNight,
 statusSuccessFillNight,
@@ -984,3 +990,4 @@ export const privateButtonSecondaryOnDarkDisabledForegroundColor = undefined;
 export const privateButtonPrimaryOnDarkPressedBackgroundColor = undefined;
 export const privateSkeletonShimmerStartEndColor = undefined;
 export const privateSkeletonShimmerCenterColor = undefined;
+export const privateSponsoredBannerBackgroundColor = undefined;

--- a/packages/bpk-foundations-react-native/tokens/base.react.native.android.js
+++ b/packages/bpk-foundations-react-native/tokens/base.react.native.android.js
@@ -821,7 +821,7 @@ spacingXxl,
 spacingNone,
 spacingIconText,
 };
-export const sponsoredbannerColors = {
+export const sponsoredBannerColors = {
 privateSponsoredBannerBackgroundDay,
 privateSponsoredBannerBackgroundNight,
 };

--- a/packages/bpk-foundations-react-native/tokens/base.react.native.ios.js
+++ b/packages/bpk-foundations-react-native/tokens/base.react.native.ios.js
@@ -236,6 +236,8 @@ export const privateSkeletonShimmerStartEndDay = "rgba(255, 255, 255, 0)";
 export const privateSkeletonShimmerStartEndNight = "rgba(0, 0, 0, 0)";
 export const privateSkeletonShimmerCenterDay = "rgba(255, 255, 255, 0.6)";
 export const privateSkeletonShimmerCenterNight = "rgba(0, 0, 0, 0.2)";
+export const privateSponsoredBannerBackgroundDay = "rgb(239, 241, 242)";
+export const privateSponsoredBannerBackgroundNight = "rgb(36, 51, 70)";
 export const animationDurationXs = 50;
 export const animationDurationSm = 200;
 export const animationDurationBase = 400;
@@ -846,6 +848,10 @@ spacingXxl,
 spacingNone,
 spacingIconText,
 };
+export const sponsoredbannerColors = {
+privateSponsoredBannerBackgroundDay,
+privateSponsoredBannerBackgroundNight,
+};
 export const statusColors = {
 statusSuccessSpotNight,
 statusSuccessFillNight,
@@ -1000,3 +1006,4 @@ export const privateButtonSecondaryOnDarkDisabledForegroundColor = undefined;
 export const privateButtonPrimaryOnDarkPressedBackgroundColor = undefined;
 export const privateSkeletonShimmerStartEndColor = undefined;
 export const privateSkeletonShimmerCenterColor = undefined;
+export const privateSponsoredBannerBackgroundColor = undefined;

--- a/packages/bpk-foundations-react-native/tokens/base.react.native.ios.js
+++ b/packages/bpk-foundations-react-native/tokens/base.react.native.ios.js
@@ -848,7 +848,7 @@ spacingXxl,
 spacingNone,
 spacingIconText,
 };
-export const sponsoredbannerColors = {
+export const sponsoredBannerColors = {
 privateSponsoredBannerBackgroundDay,
 privateSponsoredBannerBackgroundNight,
 };

--- a/packages/bpk-foundations-react-native/tokens/ios/base.react.native.common.js
+++ b/packages/bpk-foundations-react-native/tokens/ios/base.react.native.common.js
@@ -237,6 +237,8 @@ module.exports = {
   privateSkeletonShimmerStartEndNight: "rgba(0, 0, 0, 0)",
   privateSkeletonShimmerCenterDay: "rgba(255, 255, 255, 0.6)",
   privateSkeletonShimmerCenterNight: "rgba(0, 0, 0, 0.2)",
+  privateSponsoredBannerBackgroundDay: "rgb(239, 241, 242)",
+  privateSponsoredBannerBackgroundNight: "rgb(36, 51, 70)",
   animationDurationXs: 50,
   animationDurationSm: 200,
   animationDurationBase: 400,

--- a/packages/bpk-foundations-react-native/tokens/ios/base.react.native.es6.js
+++ b/packages/bpk-foundations-react-native/tokens/ios/base.react.native.es6.js
@@ -236,6 +236,8 @@ export const privateSkeletonShimmerStartEndDay = "rgba(255, 255, 255, 0)";
 export const privateSkeletonShimmerStartEndNight = "rgba(0, 0, 0, 0)";
 export const privateSkeletonShimmerCenterDay = "rgba(255, 255, 255, 0.6)";
 export const privateSkeletonShimmerCenterNight = "rgba(0, 0, 0, 0.2)";
+export const privateSponsoredBannerBackgroundDay = "rgb(239, 241, 242)";
+export const privateSponsoredBannerBackgroundNight = "rgb(36, 51, 70)";
 export const animationDurationXs = 50;
 export const animationDurationSm = 200;
 export const animationDurationBase = 400;
@@ -846,6 +848,10 @@ spacingXxl,
 spacingNone,
 spacingIconText,
 };
+export const sponsoredbannerColors = {
+privateSponsoredBannerBackgroundDay,
+privateSponsoredBannerBackgroundNight,
+};
 export const statusColors = {
 statusSuccessSpotNight,
 statusSuccessFillNight,
@@ -1000,3 +1006,4 @@ export const privateButtonSecondaryOnDarkDisabledForegroundColor = undefined;
 export const privateButtonPrimaryOnDarkPressedBackgroundColor = undefined;
 export const privateSkeletonShimmerStartEndColor = undefined;
 export const privateSkeletonShimmerCenterColor = undefined;
+export const privateSponsoredBannerBackgroundColor = undefined;

--- a/packages/bpk-foundations-react-native/tokens/ios/base.react.native.es6.js
+++ b/packages/bpk-foundations-react-native/tokens/ios/base.react.native.es6.js
@@ -848,7 +848,7 @@ spacingXxl,
 spacingNone,
 spacingIconText,
 };
-export const sponsoredbannerColors = {
+export const sponsoredBannerColors = {
 privateSponsoredBannerBackgroundDay,
 privateSponsoredBannerBackgroundNight,
 };

--- a/packages/bpk-foundations-web/package-lock.json
+++ b/packages/bpk-foundations-web/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@skyscanner/bpk-foundations-web",
-			"version": "17.0.0",
+			"version": "17.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"color": "^3.0.0"

--- a/packages/bpk-foundations-web/tokens/base.common.js
+++ b/packages/bpk-foundations-web/tokens/base.common.js
@@ -237,6 +237,8 @@ module.exports = {
   privateSkeletonShimmerStartEndNight: "rgba(0, 0, 0, 0)",
   privateSkeletonShimmerCenterDay: "rgba(255, 255, 255, 0.6)",
   privateSkeletonShimmerCenterNight: "rgba(0, 0, 0, 0.2)",
+  privateSponsoredBannerBackgroundDay: "rgb(239, 241, 242)",
+  privateSponsoredBannerBackgroundNight: "rgb(36, 51, 70)",
   durationXs: "50ms",
   durationSm: "200ms",
   durationBase: "400ms",

--- a/packages/bpk-foundations-web/tokens/base.default.scss
+++ b/packages/bpk-foundations-web/tokens/base.default.scss
@@ -453,6 +453,10 @@ $bpk-private-skeleton-shimmer-start-end-night: rgba(0, 0, 0, 0) !default;
 $bpk-private-skeleton-shimmer-center-day: rgba(255, 255, 255, 0.6) !default;
 /// @group skeleton-colors
 $bpk-private-skeleton-shimmer-center-night: rgba(0, 0, 0, 0.2) !default;
+/// @group sponsoredbanner-colors
+$bpk-private-sponsored-banner-background-day: rgb(239, 241, 242) !default;
+/// @group sponsoredbanner-colors
+$bpk-private-sponsored-banner-background-night: rgb(36, 51, 70) !default;
 /// @group animations
 $bpk-duration-xs: 50ms !default;
 /// @group animations

--- a/packages/bpk-foundations-web/tokens/base.default.scss
+++ b/packages/bpk-foundations-web/tokens/base.default.scss
@@ -453,9 +453,9 @@ $bpk-private-skeleton-shimmer-start-end-night: rgba(0, 0, 0, 0) !default;
 $bpk-private-skeleton-shimmer-center-day: rgba(255, 255, 255, 0.6) !default;
 /// @group skeleton-colors
 $bpk-private-skeleton-shimmer-center-night: rgba(0, 0, 0, 0.2) !default;
-/// @group sponsoredbanner-colors
+/// @group sponsored-banner-colors
 $bpk-private-sponsored-banner-background-day: rgb(239, 241, 242) !default;
-/// @group sponsoredbanner-colors
+/// @group sponsored-banner-colors
 $bpk-private-sponsored-banner-background-night: rgb(36, 51, 70) !default;
 /// @group animations
 $bpk-duration-xs: 50ms !default;

--- a/packages/bpk-foundations-web/tokens/base.es6.js
+++ b/packages/bpk-foundations-web/tokens/base.es6.js
@@ -669,7 +669,7 @@ onePixelRem,
 spacingNone,
 spacingIconText,
 };
-export const sponsoredbannerColors = {
+export const sponsoredBannerColors = {
 privateSponsoredBannerBackgroundDay,
 privateSponsoredBannerBackgroundNight,
 };

--- a/packages/bpk-foundations-web/tokens/base.es6.js
+++ b/packages/bpk-foundations-web/tokens/base.es6.js
@@ -235,6 +235,8 @@ export const privateSkeletonShimmerStartEndDay = "rgba(255, 255, 255, 0)";
 export const privateSkeletonShimmerStartEndNight = "rgba(0, 0, 0, 0)";
 export const privateSkeletonShimmerCenterDay = "rgba(255, 255, 255, 0.6)";
 export const privateSkeletonShimmerCenterNight = "rgba(0, 0, 0, 0.2)";
+export const privateSponsoredBannerBackgroundDay = "rgb(239, 241, 242)";
+export const privateSponsoredBannerBackgroundNight = "rgb(36, 51, 70)";
 export const durationXs = "50ms";
 export const durationSm = "200ms";
 export const durationBase = "400ms";
@@ -666,6 +668,10 @@ export const spacings = {
 onePixelRem,
 spacingNone,
 spacingIconText,
+};
+export const sponsoredbannerColors = {
+privateSponsoredBannerBackgroundDay,
+privateSponsoredBannerBackgroundNight,
 };
 export const statusColors = {
 statusSuccessSpotNight,

--- a/packages/bpk-foundations-web/tokens/base.raw.json
+++ b/packages/bpk-foundations-web/tokens/base.raw.json
@@ -2043,14 +2043,14 @@
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "rgb(239, 241, 242)",
       "originalValue": "{!GREY_10}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY"
     },
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT": {
       "type": "color",
-      "category": "sponsoredbanner-colors",
+      "category": "sponsored-banner-colors",
       "value": "rgb(36, 51, 70)",
       "originalValue": "{!NIGHT_GREY_25}",
       "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT"

--- a/packages/bpk-foundations-web/tokens/base.raw.json
+++ b/packages/bpk-foundations-web/tokens/base.raw.json
@@ -2041,6 +2041,20 @@
       "originalValue": "#00000033",
       "name": "PRIVATE_SKELETON_SHIMMER_CENTER_NIGHT"
     },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "rgb(239, 241, 242)",
+      "originalValue": "{!GREY_10}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_DAY"
+    },
+    "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT": {
+      "type": "color",
+      "category": "sponsoredbanner-colors",
+      "value": "rgb(36, 51, 70)",
+      "originalValue": "{!NIGHT_GREY_25}",
+      "name": "PRIVATE_SPONSORED_BANNER_BACKGROUND_NIGHT"
+    },
     "DURATION_XS": {
       "type": "duration",
       "category": "animations",

--- a/packages/bpk-foundations-web/tokens/base.scss
+++ b/packages/bpk-foundations-web/tokens/base.scss
@@ -453,6 +453,10 @@ $bpk-private-skeleton-shimmer-start-end-night: rgba(0, 0, 0, 0);
 $bpk-private-skeleton-shimmer-center-day: rgba(255, 255, 255, 0.6);
 /// @group skeleton-colors
 $bpk-private-skeleton-shimmer-center-night: rgba(0, 0, 0, 0.2);
+/// @group sponsoredbanner-colors
+$bpk-private-sponsored-banner-background-day: rgb(239, 241, 242);
+/// @group sponsoredbanner-colors
+$bpk-private-sponsored-banner-background-night: rgb(36, 51, 70);
 /// @group animations
 $bpk-duration-xs: 50ms;
 /// @group animations

--- a/packages/bpk-foundations-web/tokens/base.scss
+++ b/packages/bpk-foundations-web/tokens/base.scss
@@ -453,9 +453,9 @@ $bpk-private-skeleton-shimmer-start-end-night: rgba(0, 0, 0, 0);
 $bpk-private-skeleton-shimmer-center-day: rgba(255, 255, 255, 0.6);
 /// @group skeleton-colors
 $bpk-private-skeleton-shimmer-center-night: rgba(0, 0, 0, 0.2);
-/// @group sponsoredbanner-colors
+/// @group sponsored-banner-colors
 $bpk-private-sponsored-banner-background-day: rgb(239, 241, 242);
-/// @group sponsoredbanner-colors
+/// @group sponsored-banner-colors
 $bpk-private-sponsored-banner-background-night: rgb(36, 51, 70);
 /// @group animations
 $bpk-duration-xs: 50ms;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

This PR aims to create a private token in Android and iOS to match the following semantic colours:
- In Light mode: Grey 10
- In Dark mode: Night Grey 25

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated for changes to tokens and icons
