### PR TITLE
DTO-5235 New token colour required for modal

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,0 +1,3 @@
+**Added:**
+
+- Added a new dark colour token for modal

--- a/packages/bpk-foundations-web/src/base/modals.json
+++ b/packages/bpk-foundations-web/src/base/modals.json
@@ -10,6 +10,10 @@
       "value": "{!WHITE}",
       "type": "color"
     },
+    "MODAL_SURFACE_CONTRAST": {
+      "value": "{!DARK_SKY}",
+      "type": "color"
+    },
     "MODAL_INITIAL_OPACITY": {
       "value": "0",
       "type": "number"

--- a/packages/bpk-foundations-web/tokens/base.common.js
+++ b/packages/bpk-foundations-web/tokens/base.common.js
@@ -331,6 +331,7 @@ module.exports = {
   iconSizeSm: "1rem",
   iconSizeLg: "1.5rem",
   modalBackgroundColor: "rgb(255, 255, 255)",
+  modalSurfaceContrast: "rgb(5, 32, 60)",
   modalInitialOpacity: "0",
   modalOpacity: "1",
   modalMaxWidth: "32rem",

--- a/packages/bpk-foundations-web/tokens/base.default.scss
+++ b/packages/bpk-foundations-web/tokens/base.default.scss
@@ -642,6 +642,8 @@ $bpk-icon-size-lg: 1.5rem !default;
 /// @group modals
 $bpk-modal-background-color: rgb(255, 255, 255) !default;
 /// @group modals
+$bpk-modal-surface-contrast: rgb(5, 32, 60) !default;
+/// @group modals
 $bpk-modal-initial-opacity: 0 !default;
 /// @group modals
 $bpk-modal-opacity: 1 !default;

--- a/packages/bpk-foundations-web/tokens/base.es6.js
+++ b/packages/bpk-foundations-web/tokens/base.es6.js
@@ -329,6 +329,7 @@ export const horizontalNavBarSelectedColor = "rgb(0, 98, 227)";
 export const iconSizeSm = "1rem";
 export const iconSizeLg = "1.5rem";
 export const modalBackgroundColor = "rgb(255, 255, 255)";
+export const modalSurfaceContrast = "rgb(5, 32, 60)";
 export const modalInitialOpacity = "0";
 export const modalOpacity = "1";
 export const modalMaxWidth = "32rem";
@@ -670,6 +671,7 @@ marcommsEcoGreen,
 };
 export const modals = {
 modalBackgroundColor,
+modalSurfaceContrast,
 modalInitialOpacity,
 modalOpacity,
 modalMaxWidth,

--- a/packages/bpk-foundations-web/tokens/base.raw.json
+++ b/packages/bpk-foundations-web/tokens/base.raw.json
@@ -2705,6 +2705,13 @@
       "originalValue": "{!WHITE}",
       "name": "MODAL_BACKGROUND_COLOR"
     },
+    "MODAL_SURFACE_CONTRAST": {
+      "category": "modals",
+      "value": "rgb(5, 32, 60)",
+      "type": "color",
+      "originalValue": "{!DARK_SKY}",
+      "name": "MODAL_SURFACE_CONTRAST"
+    },
     "MODAL_INITIAL_OPACITY": {
       "category": "modals",
       "value": "0",

--- a/packages/bpk-foundations-web/tokens/base.scss
+++ b/packages/bpk-foundations-web/tokens/base.scss
@@ -642,6 +642,8 @@ $bpk-icon-size-lg: 1.5rem;
 /// @group modals
 $bpk-modal-background-color: rgb(255, 255, 255);
 /// @group modals
+$bpk-modal-surface-contrast: rgb(5, 32, 60);
+/// @group modals
 $bpk-modal-initial-opacity: 0;
 /// @group modals
 $bpk-modal-opacity: 1;


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Require a new token to change the colour of the modal from light to dark colour (dark colour known as surface contrast).

Figma requirements for two modal colour options (focussing on dark colour modal for this PR):
https://www.figma.com/file/yN0hFyZlKL0Jwbpi0rEKYT/Backpack-Beta?type=design&node-id=24375-163&mode=design&t=9q9PLNPE0jQ1pGSp-0

Remember to include the following changes:

- [x] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated for changes to tokens and icons
