### PR TITLE
[WIP] BPKCardButton contained fill private token

### DIFF
--- a/packages/bpk-foundations-android/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-android/tokens/base.raw.android.json
@@ -3242,6 +3242,20 @@
       "originalValue": "{!WHITE}",
       "name": "PRIVATE_NAVIGATION_TAB_OUTLINE_NIGHT"
     },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "originalValue": "{!WHITE_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY"
+    },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#000000cc",
+      "originalValue": "{!BLACK_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT"
+    },
     "ANIMATION_DURATION_XS": {
       "type": "duration",
       "value": "50ms",
@@ -4323,6 +4337,15 @@
       "name": "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR",
       "darkValue": "#ffffffff",
       "originalDarkValue": "{!WHITE}"
+    },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "originalValue": "{!WHITE_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR",
+      "darkValue": "#000000cc",
+      "originalDarkValue": "{!BLACK_ALPHA_80}"
     }
   },
   "propKeys": [
@@ -4710,6 +4733,8 @@
     "PRIVATE_NAVIGATION_TAB_HOVER_NIGHT",
     "PRIVATE_NAVIGATION_TAB_OUTLINE_DAY",
     "PRIVATE_NAVIGATION_TAB_OUTLINE_NIGHT",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT",
     "ANIMATION_DURATION_XS",
     "ANIMATION_DURATION_SM",
     "ANIMATION_DURATION_BASE",
@@ -4836,6 +4861,7 @@
     "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",
     "PRIVATE_NAVIGATION_TAB_HOVER_COLOR",
-    "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR"
+    "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR"
   ]
 }

--- a/packages/bpk-foundations-common/base/colors.json
+++ b/packages/bpk-foundations-common/base/colors.json
@@ -16,6 +16,7 @@
     "./colors/rating-bar.json",
     "./colors/skeleton.json",
     "./colors/sponsored-banner.json",
-    "./colors/navigation-tab.json"
+    "./colors/navigation-tab.json",
+    "./colors/card-button.json"
   ]
 }

--- a/packages/bpk-foundations-common/base/colors/card-button.json
+++ b/packages/bpk-foundations-common/base/colors/card-button.json
@@ -1,0 +1,15 @@
+{
+    "imports": ["./aliases.json"],
+    "global": {
+      "type": "color",
+      "category": "card-button-colors"
+    },
+    "props": {
+      "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY": {
+        "value": "{!WHITE_ALPHA_80}"
+      },
+      "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT": {
+        "value": "{!BLACK_ALPHA_80}"
+      }
+    }
+  }

--- a/packages/bpk-foundations-ios/tokens/base.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.ios.json
@@ -2806,6 +2806,20 @@
       "name": "privateNavigationTabOutlineNight"
     },
     {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "originalValue": "{!WHITE_ALPHA_80}",
+      "name": "privateCardButtonContainedFillDay"
+    },
+    {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#000000cc",
+      "originalValue": "{!BLACK_ALPHA_80}",
+      "name": "privateCardButtonContainedFillNight"
+    },
+    {
       "type": "duration",
       "value": "50ms",
       "category": "animations",
@@ -4090,6 +4104,15 @@
       "name": "privateNavigationTabOutlineColor",
       "darkValue": "#ffffffff",
       "originalDarkValue": "{!WHITE}"
+    },
+    {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "originalValue": "{!WHITE_ALPHA_80}",
+      "name": "privateCardButtonContainedFillColor",
+      "darkValue": "#000000cc",
+      "originalDarkValue": "{!BLACK_ALPHA_80}"
     }
   ]
 }

--- a/packages/bpk-foundations-ios/tokens/base.raw.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.raw.ios.json
@@ -3242,6 +3242,20 @@
       "originalValue": "{!WHITE}",
       "name": "PRIVATE_NAVIGATION_TAB_OUTLINE_NIGHT"
     },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "originalValue": "{!WHITE_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY"
+    },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#000000cc",
+      "originalValue": "{!BLACK_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT"
+    },
     "ANIMATION_DURATION_XS": {
       "type": "duration",
       "value": "50ms",
@@ -4527,6 +4541,15 @@
       "name": "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR",
       "darkValue": "#ffffffff",
       "originalDarkValue": "{!WHITE}"
+    },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "originalValue": "{!WHITE_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR",
+      "darkValue": "#000000cc",
+      "originalDarkValue": "{!BLACK_ALPHA_80}"
     }
   },
   "propKeys": [
@@ -4914,6 +4937,8 @@
     "PRIVATE_NAVIGATION_TAB_HOVER_NIGHT",
     "PRIVATE_NAVIGATION_TAB_OUTLINE_DAY",
     "PRIVATE_NAVIGATION_TAB_OUTLINE_NIGHT",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT",
     "ANIMATION_DURATION_XS",
     "ANIMATION_DURATION_SM",
     "ANIMATION_DURATION_BASE",
@@ -5069,6 +5094,7 @@
     "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",
     "PRIVATE_NAVIGATION_TAB_HOVER_COLOR",
-    "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR"
+    "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR"
   ]
 }

--- a/packages/bpk-foundations-react-native/tokens/android/base.react.native.common.js
+++ b/packages/bpk-foundations-react-native/tokens/android/base.react.native.common.js
@@ -265,6 +265,8 @@ module.exports = {
   privateNavigationTabHoverNight: "rgb(209, 247, 255)",
   privateNavigationTabOutlineDay: "rgb(193, 199, 207)",
   privateNavigationTabOutlineNight: "rgb(255, 255, 255)",
+  privateCardButtonContainedFillDay: "rgba(255, 255, 255, 0.8)",
+  privateCardButtonContainedFillNight: "rgba(0, 0, 0, 0.8)",
   animationDurationXs: 50,
   animationDurationSm: 200,
   animationDurationBase: 400,

--- a/packages/bpk-foundations-react-native/tokens/android/base.react.native.es6.js
+++ b/packages/bpk-foundations-react-native/tokens/android/base.react.native.es6.js
@@ -264,6 +264,8 @@ export const privateNavigationTabHoverDay = "rgb(21, 70, 121)";
 export const privateNavigationTabHoverNight = "rgb(209, 247, 255)";
 export const privateNavigationTabOutlineDay = "rgb(193, 199, 207)";
 export const privateNavigationTabOutlineNight = "rgb(255, 255, 255)";
+export const privateCardButtonContainedFillDay = "rgba(255, 255, 255, 0.8)";
+export const privateCardButtonContainedFillNight = "rgba(0, 0, 0, 0.8)";
 export const animationDurationXs = 50;
 export const animationDurationSm = 200;
 export const animationDurationBase = 400;
@@ -593,6 +595,10 @@ canvasDay,
 canvasNight,
 canvasContrastDay,
 canvasContrastNight,
+};
+export const cardButtonColors = {
+privateCardButtonContainedFillDay,
+privateCardButtonContainedFillNight,
 };
 export const carouselIndicatorDots = {
 carouselIndicatorDotSizeSm,
@@ -1064,3 +1070,4 @@ export const privateSkeletonShimmerCenterColor = undefined;
 export const privateSponsoredBannerBackgroundColor = undefined;
 export const privateNavigationTabHoverColor = undefined;
 export const privateNavigationTabOutlineColor = undefined;
+export const privateCardButtonContainedFillColor = undefined;

--- a/packages/bpk-foundations-react-native/tokens/base.android.xml
+++ b/packages/bpk-foundations-react-native/tokens/base.android.xml
@@ -246,6 +246,8 @@
   <color name="PRIVATE_NAVIGATION_TAB_HOVER_NIGHT" category="navigation-tab-colors">#d1f7ffff</color>
   <color name="PRIVATE_NAVIGATION_TAB_OUTLINE_DAY" category="navigation-tab-colors">#c1c7cfff</color>
   <color name="PRIVATE_NAVIGATION_TAB_OUTLINE_NIGHT" category="navigation-tab-colors">#ffffffff</color>
+  <color name="PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY" category="card-button-colors">#ffffffcc</color>
+  <color name="PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT" category="card-button-colors">#000000cc</color>
   <property name="ANIMATION_DURATION_XS" category="animations">50ms</property>
   <property name="ANIMATION_DURATION_SM" category="animations">200ms</property>
   <property name="ANIMATION_DURATION_BASE" category="animations">400ms</property>

--- a/packages/bpk-foundations-react-native/tokens/base.ios.json
+++ b/packages/bpk-foundations-react-native/tokens/base.ios.json
@@ -1535,6 +1535,18 @@
       "name": "privateNavigationTabOutlineNight"
     },
     {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "name": "privateCardButtonContainedFillDay"
+    },
+    {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#000000cc",
+      "name": "privateCardButtonContainedFillNight"
+    },
+    {
       "type": "duration",
       "value": "50ms",
       "category": "animations",
@@ -2762,6 +2774,13 @@
       "value": "#c1c7cfff",
       "name": "privateNavigationTabOutlineColor",
       "darkValue": "#ffffffff"
+    },
+    {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "name": "privateCardButtonContainedFillColor",
+      "darkValue": "#000000cc"
     }
   ]
 }

--- a/packages/bpk-foundations-react-native/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-react-native/tokens/base.raw.android.json
@@ -2193,6 +2193,20 @@
       "originalValue": "{!WHITE}",
       "name": "PRIVATE_NAVIGATION_TAB_OUTLINE_NIGHT"
     },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "originalValue": "{!WHITE_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY"
+    },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#000000cc",
+      "originalValue": "{!BLACK_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT"
+    },
     "ANIMATION_DURATION_XS": {
       "type": "duration",
       "value": "50ms",
@@ -3601,6 +3615,15 @@
       "name": "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR",
       "darkValue": "#ffffffff",
       "originalDarkValue": "{!WHITE}"
+    },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "originalValue": "{!WHITE_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR",
+      "darkValue": "#000000cc",
+      "originalDarkValue": "{!BLACK_ALPHA_80}"
     }
   },
   "propKeys": [
@@ -3850,6 +3873,8 @@
     "PRIVATE_NAVIGATION_TAB_HOVER_NIGHT",
     "PRIVATE_NAVIGATION_TAB_OUTLINE_DAY",
     "PRIVATE_NAVIGATION_TAB_OUTLINE_NIGHT",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT",
     "ANIMATION_DURATION_XS",
     "ANIMATION_DURATION_SM",
     "ANIMATION_DURATION_BASE",
@@ -4023,6 +4048,7 @@
     "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",
     "PRIVATE_NAVIGATION_TAB_HOVER_COLOR",
-    "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR"
+    "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR"
   ]
 }

--- a/packages/bpk-foundations-react-native/tokens/base.raw.ios.json
+++ b/packages/bpk-foundations-react-native/tokens/base.raw.ios.json
@@ -2172,6 +2172,20 @@
       "originalValue": "{!WHITE}",
       "name": "PRIVATE_NAVIGATION_TAB_OUTLINE_NIGHT"
     },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "originalValue": "{!WHITE_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY"
+    },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#000000cc",
+      "originalValue": "{!BLACK_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT"
+    },
     "ANIMATION_DURATION_XS": {
       "type": "duration",
       "value": "50ms",
@@ -3679,6 +3693,15 @@
       "name": "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR",
       "darkValue": "#ffffffff",
       "originalDarkValue": "{!WHITE}"
+    },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "#ffffffcc",
+      "originalValue": "{!WHITE_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR",
+      "darkValue": "#000000cc",
+      "originalDarkValue": "{!BLACK_ALPHA_80}"
     }
   },
   "propKeys": [
@@ -3928,6 +3951,8 @@
     "PRIVATE_NAVIGATION_TAB_HOVER_NIGHT",
     "PRIVATE_NAVIGATION_TAB_OUTLINE_DAY",
     "PRIVATE_NAVIGATION_TAB_OUTLINE_NIGHT",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT",
     "ANIMATION_DURATION_XS",
     "ANIMATION_DURATION_SM",
     "ANIMATION_DURATION_BASE",
@@ -4115,6 +4140,7 @@
     "PRIVATE_SKELETON_SHIMMER_CENTER_COLOR",
     "PRIVATE_SPONSORED_BANNER_BACKGROUND_COLOR",
     "PRIVATE_NAVIGATION_TAB_HOVER_COLOR",
-    "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR"
+    "PRIVATE_NAVIGATION_TAB_OUTLINE_COLOR",
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_COLOR"
   ]
 }

--- a/packages/bpk-foundations-react-native/tokens/base.react.native.android.js
+++ b/packages/bpk-foundations-react-native/tokens/base.react.native.android.js
@@ -264,6 +264,8 @@ export const privateNavigationTabHoverDay = "rgb(21, 70, 121)";
 export const privateNavigationTabHoverNight = "rgb(209, 247, 255)";
 export const privateNavigationTabOutlineDay = "rgb(193, 199, 207)";
 export const privateNavigationTabOutlineNight = "rgb(255, 255, 255)";
+export const privateCardButtonContainedFillDay = "rgba(255, 255, 255, 0.8)";
+export const privateCardButtonContainedFillNight = "rgba(0, 0, 0, 0.8)";
 export const animationDurationXs = 50;
 export const animationDurationSm = 200;
 export const animationDurationBase = 400;
@@ -593,6 +595,10 @@ canvasDay,
 canvasNight,
 canvasContrastDay,
 canvasContrastNight,
+};
+export const cardButtonColors = {
+privateCardButtonContainedFillDay,
+privateCardButtonContainedFillNight,
 };
 export const carouselIndicatorDots = {
 carouselIndicatorDotSizeSm,
@@ -1064,3 +1070,4 @@ export const privateSkeletonShimmerCenterColor = undefined;
 export const privateSponsoredBannerBackgroundColor = undefined;
 export const privateNavigationTabHoverColor = undefined;
 export const privateNavigationTabOutlineColor = undefined;
+export const privateCardButtonContainedFillColor = undefined;

--- a/packages/bpk-foundations-react-native/tokens/base.react.native.ios.js
+++ b/packages/bpk-foundations-react-native/tokens/base.react.native.ios.js
@@ -264,6 +264,8 @@ export const privateNavigationTabHoverDay = "rgb(21, 70, 121)";
 export const privateNavigationTabHoverNight = "rgb(209, 247, 255)";
 export const privateNavigationTabOutlineDay = "rgb(193, 199, 207)";
 export const privateNavigationTabOutlineNight = "rgb(255, 255, 255)";
+export const privateCardButtonContainedFillDay = "rgba(255, 255, 255, 0.8)";
+export const privateCardButtonContainedFillNight = "rgba(0, 0, 0, 0.8)";
 export const animationDurationXs = 50;
 export const animationDurationSm = 200;
 export const animationDurationBase = 400;
@@ -622,6 +624,10 @@ canvasDay,
 canvasNight,
 canvasContrastDay,
 canvasContrastNight,
+};
+export const cardButtonColors = {
+privateCardButtonContainedFillDay,
+privateCardButtonContainedFillNight,
 };
 export const carouselIndicatorDots = {
 carouselIndicatorDotSizeSm,
@@ -1080,3 +1086,4 @@ export const privateSkeletonShimmerCenterColor = undefined;
 export const privateSponsoredBannerBackgroundColor = undefined;
 export const privateNavigationTabHoverColor = undefined;
 export const privateNavigationTabOutlineColor = undefined;
+export const privateCardButtonContainedFillColor = undefined;

--- a/packages/bpk-foundations-react-native/tokens/ios/base.react.native.common.js
+++ b/packages/bpk-foundations-react-native/tokens/ios/base.react.native.common.js
@@ -265,6 +265,8 @@ module.exports = {
   privateNavigationTabHoverNight: "rgb(209, 247, 255)",
   privateNavigationTabOutlineDay: "rgb(193, 199, 207)",
   privateNavigationTabOutlineNight: "rgb(255, 255, 255)",
+  privateCardButtonContainedFillDay: "rgba(255, 255, 255, 0.8)",
+  privateCardButtonContainedFillNight: "rgba(0, 0, 0, 0.8)",
   animationDurationXs: 50,
   animationDurationSm: 200,
   animationDurationBase: 400,

--- a/packages/bpk-foundations-react-native/tokens/ios/base.react.native.es6.js
+++ b/packages/bpk-foundations-react-native/tokens/ios/base.react.native.es6.js
@@ -264,6 +264,8 @@ export const privateNavigationTabHoverDay = "rgb(21, 70, 121)";
 export const privateNavigationTabHoverNight = "rgb(209, 247, 255)";
 export const privateNavigationTabOutlineDay = "rgb(193, 199, 207)";
 export const privateNavigationTabOutlineNight = "rgb(255, 255, 255)";
+export const privateCardButtonContainedFillDay = "rgba(255, 255, 255, 0.8)";
+export const privateCardButtonContainedFillNight = "rgba(0, 0, 0, 0.8)";
 export const animationDurationXs = 50;
 export const animationDurationSm = 200;
 export const animationDurationBase = 400;
@@ -622,6 +624,10 @@ canvasDay,
 canvasNight,
 canvasContrastDay,
 canvasContrastNight,
+};
+export const cardButtonColors = {
+privateCardButtonContainedFillDay,
+privateCardButtonContainedFillNight,
 };
 export const carouselIndicatorDots = {
 carouselIndicatorDotSizeSm,
@@ -1080,3 +1086,4 @@ export const privateSkeletonShimmerCenterColor = undefined;
 export const privateSponsoredBannerBackgroundColor = undefined;
 export const privateNavigationTabHoverColor = undefined;
 export const privateNavigationTabOutlineColor = undefined;
+export const privateCardButtonContainedFillColor = undefined;

--- a/packages/bpk-foundations-web/tokens/base.common.js
+++ b/packages/bpk-foundations-web/tokens/base.common.js
@@ -265,6 +265,8 @@ module.exports = {
   privateNavigationTabHoverNight: "rgb(209, 247, 255)",
   privateNavigationTabOutlineDay: "rgb(193, 199, 207)",
   privateNavigationTabOutlineNight: "rgb(255, 255, 255)",
+  privateCardButtonContainedFillDay: "rgba(255, 255, 255, 0.8)",
+  privateCardButtonContainedFillNight: "rgba(0, 0, 0, 0.8)",
   durationXs: "50ms",
   durationSm: "200ms",
   durationBase: "400ms",

--- a/packages/bpk-foundations-web/tokens/base.default.scss
+++ b/packages/bpk-foundations-web/tokens/base.default.scss
@@ -509,6 +509,10 @@ $bpk-private-navigation-tab-hover-night: rgb(209, 247, 255) !default;
 $bpk-private-navigation-tab-outline-day: rgb(193, 199, 207) !default;
 /// @group navigation-tab-colors
 $bpk-private-navigation-tab-outline-night: rgb(255, 255, 255) !default;
+/// @group card-button-colors
+$bpk-private-card-button-contained-fill-day: rgba(255, 255, 255, 0.8) !default;
+/// @group card-button-colors
+$bpk-private-card-button-contained-fill-night: rgba(0, 0, 0, 0.8) !default;
 /// @group animations
 $bpk-duration-xs: 50ms !default;
 /// @group animations

--- a/packages/bpk-foundations-web/tokens/base.es6.js
+++ b/packages/bpk-foundations-web/tokens/base.es6.js
@@ -263,6 +263,8 @@ export const privateNavigationTabHoverDay = "rgb(21, 70, 121)";
 export const privateNavigationTabHoverNight = "rgb(209, 247, 255)";
 export const privateNavigationTabOutlineDay = "rgb(193, 199, 207)";
 export const privateNavigationTabOutlineNight = "rgb(255, 255, 255)";
+export const privateCardButtonContainedFillDay = "rgba(255, 255, 255, 0.8)";
+export const privateCardButtonContainedFillNight = "rgba(0, 0, 0, 0.8)";
 export const durationXs = "50ms";
 export const durationSm = "200ms";
 export const durationBase = "400ms";
@@ -499,6 +501,10 @@ canvasDay,
 canvasNight,
 canvasContrastDay,
 canvasContrastNight,
+};
+export const cardButtonColors = {
+privateCardButtonContainedFillDay,
+privateCardButtonContainedFillNight,
 };
 export const cards = {
 cardBackgroundColor,

--- a/packages/bpk-foundations-web/tokens/base.raw.json
+++ b/packages/bpk-foundations-web/tokens/base.raw.json
@@ -2243,6 +2243,20 @@
       "originalValue": "{!WHITE}",
       "name": "PRIVATE_NAVIGATION_TAB_OUTLINE_NIGHT"
     },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "rgba(255, 255, 255, 0.8)",
+      "originalValue": "{!WHITE_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_DAY"
+    },
+    "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT": {
+      "type": "color",
+      "category": "card-button-colors",
+      "value": "rgba(0, 0, 0, 0.8)",
+      "originalValue": "{!BLACK_ALPHA_80}",
+      "name": "PRIVATE_CARD_BUTTON_CONTAINED_FILL_NIGHT"
+    },
     "DURATION_XS": {
       "type": "duration",
       "category": "animations",

--- a/packages/bpk-foundations-web/tokens/base.scss
+++ b/packages/bpk-foundations-web/tokens/base.scss
@@ -509,6 +509,10 @@ $bpk-private-navigation-tab-hover-night: rgb(209, 247, 255);
 $bpk-private-navigation-tab-outline-day: rgb(193, 199, 207);
 /// @group navigation-tab-colors
 $bpk-private-navigation-tab-outline-night: rgb(255, 255, 255);
+/// @group card-button-colors
+$bpk-private-card-button-contained-fill-day: rgba(255, 255, 255, 0.8);
+/// @group card-button-colors
+$bpk-private-card-button-contained-fill-night: rgba(0, 0, 0, 0.8);
 /// @group animations
 $bpk-duration-xs: 50ms;
 /// @group animations


### PR DESCRIPTION
Add a new private token for the card button contained circle.
On iOS we use a custom white.opacity(0.5) which is wrong, it should be white.opacity(0.8).

introducing the private token will help to prevent mistakes in the future and align all implementations

Remember to include the following changes:

- [ ] `UNRELEASED.md` (See [How to write a good changelog entry](https://github.com/Skyscanner/backpack-foundations/blob/main/CHANGELOG_FORMAT.md))
- [ ] `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated for changes to tokens and icons
