### PR TITLE
[MUON-1044] Update weight in `typography.json`

### DIFF
--- a/packages/bpk-foundations-android/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-android/tokens/base.raw.android.json
@@ -75,6 +75,9 @@
     "LINE_HEIGHT_LG": {
       "value": 28
     },
+    "FONT_WEIGHT_BLACK": {
+      "value": "900"
+    },
     "LINE_HEIGHT_XS": {
       "value": 16
     },
@@ -146,9 +149,6 @@
     },
     "FONT_SIZE_CAPS": {
       "value": 10
-    },
-    "FONT_WEIGHT_BLACK": {
-      "value": "900"
     },
     "ANIMATION_DURATION_XS": {
       "value": "50ms"
@@ -850,10 +850,10 @@
       "name": "TEXT_SUBHEADING_FONT_WEIGHT"
     },
     "TEXT_HERO-5_FONT_WEIGHT": {
-      "value": "700",
+      "value": "900",
       "type": "string",
       "category": "font-weights",
-      "originalValue": "{!FONT_WEIGHT_BOLD}",
+      "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "TEXT_HERO-5_FONT_WEIGHT"
     },
     "TEXT_HEADING-1_FONT_WEIGHT": {

--- a/packages/bpk-foundations-common/app/typography.json
+++ b/packages/bpk-foundations-common/app/typography.json
@@ -29,7 +29,8 @@
     "LINE_HEIGHT_8XL": 120,
     "LETTER_SPACING_TIGHT": -0.02,
     "FONT_WEIGHT_BOOK": "400",
-    "FONT_WEIGHT_BOLD": "700"
+    "FONT_WEIGHT_BOLD": "700",
+    "FONT_WEIGHT_BLACK": "900"
   },
   "props": {
     "FONT_SIZE_XS": {
@@ -373,7 +374,7 @@
       "category": "font-sizes"
     },
     "TEXT_HERO-5_FONT_WEIGHT": {
-      "value": "{!FONT_WEIGHT_BOLD}",
+      "value": "{!FONT_WEIGHT_BLACK}",
       "type": "string",
       "category": "font-weights"
     },

--- a/packages/bpk-foundations-ios/tokens/base.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.ios.json
@@ -512,10 +512,10 @@
       "name": "textSubheadingFontWeight"
     },
     {
-      "value": "700",
+      "value": "900",
       "type": "string",
       "category": "font-weights",
-      "originalValue": "{!FONT_WEIGHT_BOLD}",
+      "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "textHero5FontWeight"
     },
     {

--- a/packages/bpk-foundations-ios/tokens/base.raw.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.raw.ios.json
@@ -75,6 +75,9 @@
     "LINE_HEIGHT_LG": {
       "value": 28
     },
+    "FONT_WEIGHT_BLACK": {
+      "value": "900"
+    },
     "LINE_HEIGHT_XS": {
       "value": 16
     },
@@ -146,9 +149,6 @@
     },
     "FONT_SIZE_CAPS": {
       "value": 10
-    },
-    "FONT_WEIGHT_BLACK": {
-      "value": "900"
     },
     "ANIMATION_DURATION_XS": {
       "value": "50ms"
@@ -850,10 +850,10 @@
       "name": "TEXT_SUBHEADING_FONT_WEIGHT"
     },
     "TEXT_HERO-5_FONT_WEIGHT": {
-      "value": "700",
+      "value": "900",
       "type": "string",
       "category": "font-weights",
-      "originalValue": "{!FONT_WEIGHT_BOLD}",
+      "originalValue": "{!FONT_WEIGHT_BLACK}",
       "name": "TEXT_HERO-5_FONT_WEIGHT"
     },
     "TEXT_HEADING-1_FONT_WEIGHT": {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:
Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Adds Black (900) font weight for the `Hero 5` text token in apps

Remember to include the following changes:

- [ ] `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated for changes to tokens and icons
