### PR TITLE
[DON-1958] Add missing spacing tokens for Android and iOS

### DIFF
--- a/packages/bpk-foundations-android/src/base/spacing.json
+++ b/packages/bpk-foundations-android/src/base/spacing.json
@@ -25,6 +25,12 @@
     "SPACING_XXL": {
       "value": "{!SPACING_XXL}"
     },
+    "SPACING_XXXL": {
+      "value": "{!SPACING_XXXL}"
+    },
+    "SPACING_XXXXL": {
+      "value": "{!SPACING_XXXXL}"
+    },
     "SPACING_NONE": {
       "value": "{!SPACING_NONE}"
     },

--- a/packages/bpk-foundations-android/tokens/base.raw.android.json
+++ b/packages/bpk-foundations-android/tokens/base.raw.android.json
@@ -39,17 +39,11 @@
     "CAROUSEL_INDICATOR_DOT_SIZE_BASE": {
       "value": 6
     },
-    "SPACING_SM": {
-      "value": 4
-    },
-    "SPACING_MD": {
-      "value": 8
-    },
     "SPACING_BASE": {
       "value": 16
     },
-    "SPACING_LG": {
-      "value": 24
+    "SPACING_XXXL": {
+      "value": 64
     },
     "SPACING_XL": {
       "value": 32
@@ -57,8 +51,20 @@
     "SPACING_XXL": {
       "value": 40
     },
+    "SPACING_XXXXL": {
+      "value": 96
+    },
+    "SPACING_MD": {
+      "value": 8
+    },
     "SPACING_NONE": {
       "value": 0
+    },
+    "SPACING_SM": {
+      "value": 4
+    },
+    "SPACING_LG": {
+      "value": 24
     },
     "FONT_WEIGHT_BOOK": {
       "value": "400"
@@ -2953,20 +2959,6 @@
       "originalValue": "{!ELEVATION_XXL}",
       "name": "ELEVATION_XXL"
     },
-    "SPACING_SM": {
-      "type": "size",
-      "category": "spacings",
-      "value": "4",
-      "originalValue": "{!SPACING_SM}",
-      "name": "SPACING_SM"
-    },
-    "SPACING_MD": {
-      "type": "size",
-      "category": "spacings",
-      "value": "8",
-      "originalValue": "{!SPACING_MD}",
-      "name": "SPACING_MD"
-    },
     "SPACING_BASE": {
       "type": "size",
       "category": "spacings",
@@ -2974,12 +2966,12 @@
       "originalValue": "{!SPACING_BASE}",
       "name": "SPACING_BASE"
     },
-    "SPACING_LG": {
+    "SPACING_XXXL": {
       "type": "size",
       "category": "spacings",
-      "value": "24",
-      "originalValue": "{!SPACING_LG}",
-      "name": "SPACING_LG"
+      "value": "64",
+      "originalValue": "{!SPACING_XXXL}",
+      "name": "SPACING_XXXL"
     },
     "SPACING_XL": {
       "type": "size",
@@ -2995,6 +2987,20 @@
       "originalValue": "{!SPACING_XXL}",
       "name": "SPACING_XXL"
     },
+    "SPACING_XXXXL": {
+      "type": "size",
+      "category": "spacings",
+      "value": "96",
+      "originalValue": "{!SPACING_XXXXL}",
+      "name": "SPACING_XXXXL"
+    },
+    "SPACING_MD": {
+      "type": "size",
+      "category": "spacings",
+      "value": "8",
+      "originalValue": "{!SPACING_MD}",
+      "name": "SPACING_MD"
+    },
     "SPACING_NONE": {
       "type": "size",
       "category": "spacings",
@@ -3002,12 +3008,26 @@
       "originalValue": "{!SPACING_NONE}",
       "name": "SPACING_NONE"
     },
+    "SPACING_SM": {
+      "type": "size",
+      "category": "spacings",
+      "value": "4",
+      "originalValue": "{!SPACING_SM}",
+      "name": "SPACING_SM"
+    },
     "SPACING_ICON_TEXT": {
       "type": "size",
       "category": "spacings",
       "value": "8",
       "originalValue": "{!SPACING_MD}",
       "name": "SPACING_ICON_TEXT"
+    },
+    "SPACING_LG": {
+      "type": "size",
+      "category": "spacings",
+      "value": "24",
+      "originalValue": "{!SPACING_LG}",
+      "name": "SPACING_LG"
     },
     "FONT_FAMILY": {
       "value": "\"sans-serif\"",
@@ -4187,14 +4207,16 @@
     "ELEVATION_LG",
     "ELEVATION_XL",
     "ELEVATION_XXL",
-    "SPACING_SM",
-    "SPACING_MD",
     "SPACING_BASE",
-    "SPACING_LG",
+    "SPACING_XXXL",
     "SPACING_XL",
     "SPACING_XXL",
+    "SPACING_XXXXL",
+    "SPACING_MD",
     "SPACING_NONE",
+    "SPACING_SM",
     "SPACING_ICON_TEXT",
+    "SPACING_LG",
     "FONT_FAMILY",
     "FONT_FAMILY_EMPHASIZE",
     "FONT_FAMILY_HEAVY",

--- a/packages/bpk-foundations-common/app/spacing.json
+++ b/packages/bpk-foundations-common/app/spacing.json
@@ -6,6 +6,8 @@
     "SPACING_LG": 24,
     "SPACING_XL": 32,
     "SPACING_XXL": 40,
+    "SPACING_XXXL": 64,
+    "SPACING_XXXXL": 96,
     "SPACING_NONE": 0
   }
 }

--- a/packages/bpk-foundations-ios/src/base/spacing.json
+++ b/packages/bpk-foundations-ios/src/base/spacing.json
@@ -25,6 +25,12 @@
     "SPACING_XXL": {
       "value": "{!SPACING_XXL}"
     },
+    "SPACING_XXXL": {
+      "value": "{!SPACING_XXXL}"
+    },
+    "SPACING_XXXXL": {
+      "value": "{!SPACING_XXXXL}"
+    },
     "SPACING_NONE": {
       "value": "{!SPACING_NONE}"
     },

--- a/packages/bpk-foundations-ios/tokens/base.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.ios.json
@@ -2693,20 +2693,6 @@
     {
       "type": "size",
       "category": "spacings",
-      "value": "4",
-      "originalValue": "{!SPACING_SM}",
-      "name": "spacingSm"
-    },
-    {
-      "type": "size",
-      "category": "spacings",
-      "value": "8",
-      "originalValue": "{!SPACING_MD}",
-      "name": "spacingMd"
-    },
-    {
-      "type": "size",
-      "category": "spacings",
       "value": "16",
       "originalValue": "{!SPACING_BASE}",
       "name": "spacingBase"
@@ -2714,9 +2700,9 @@
     {
       "type": "size",
       "category": "spacings",
-      "value": "24",
-      "originalValue": "{!SPACING_LG}",
-      "name": "spacingLg"
+      "value": "64",
+      "originalValue": "{!SPACING_XXXL}",
+      "name": "spacingXxxl"
     },
     {
       "type": "size",
@@ -2735,6 +2721,20 @@
     {
       "type": "size",
       "category": "spacings",
+      "value": "96",
+      "originalValue": "{!SPACING_XXXXL}",
+      "name": "spacingXxxxl"
+    },
+    {
+      "type": "size",
+      "category": "spacings",
+      "value": "8",
+      "originalValue": "{!SPACING_MD}",
+      "name": "spacingMd"
+    },
+    {
+      "type": "size",
+      "category": "spacings",
       "value": "0",
       "originalValue": "{!SPACING_NONE}",
       "name": "spacingNone"
@@ -2742,9 +2742,23 @@
     {
       "type": "size",
       "category": "spacings",
+      "value": "4",
+      "originalValue": "{!SPACING_SM}",
+      "name": "spacingSm"
+    },
+    {
+      "type": "size",
+      "category": "spacings",
       "value": "8",
       "originalValue": "{!SPACING_MD}",
       "name": "spacingIconText"
+    },
+    {
+      "type": "size",
+      "category": "spacings",
+      "value": "24",
+      "originalValue": "{!SPACING_LG}",
+      "name": "spacingLg"
     },
     {
       "category": "touchables",

--- a/packages/bpk-foundations-ios/tokens/base.raw.ios.json
+++ b/packages/bpk-foundations-ios/tokens/base.raw.ios.json
@@ -39,17 +39,11 @@
     "CAROUSEL_INDICATOR_DOT_SIZE_BASE": {
       "value": 6
     },
-    "SPACING_SM": {
-      "value": 4
-    },
-    "SPACING_MD": {
-      "value": 8
-    },
     "SPACING_BASE": {
       "value": 16
     },
-    "SPACING_LG": {
-      "value": 24
+    "SPACING_XXXL": {
+      "value": 64
     },
     "SPACING_XL": {
       "value": 32
@@ -57,8 +51,20 @@
     "SPACING_XXL": {
       "value": 40
     },
+    "SPACING_XXXXL": {
+      "value": 96
+    },
+    "SPACING_MD": {
+      "value": 8
+    },
     "SPACING_NONE": {
       "value": 0
+    },
+    "SPACING_SM": {
+      "value": 4
+    },
+    "SPACING_LG": {
+      "value": 24
     },
     "FONT_WEIGHT_BOOK": {
       "value": "400"
@@ -3037,20 +3043,6 @@
       "originalValue": "{!CAROUSEL_INDICATOR_DOT_SIZE_BASE}",
       "name": "CAROUSEL_INDICATOR_DOT_SIZE_BASE"
     },
-    "SPACING_SM": {
-      "type": "size",
-      "category": "spacings",
-      "value": "4",
-      "originalValue": "{!SPACING_SM}",
-      "name": "SPACING_SM"
-    },
-    "SPACING_MD": {
-      "type": "size",
-      "category": "spacings",
-      "value": "8",
-      "originalValue": "{!SPACING_MD}",
-      "name": "SPACING_MD"
-    },
     "SPACING_BASE": {
       "type": "size",
       "category": "spacings",
@@ -3058,12 +3050,12 @@
       "originalValue": "{!SPACING_BASE}",
       "name": "SPACING_BASE"
     },
-    "SPACING_LG": {
+    "SPACING_XXXL": {
       "type": "size",
       "category": "spacings",
-      "value": "24",
-      "originalValue": "{!SPACING_LG}",
-      "name": "SPACING_LG"
+      "value": "64",
+      "originalValue": "{!SPACING_XXXL}",
+      "name": "SPACING_XXXL"
     },
     "SPACING_XL": {
       "type": "size",
@@ -3079,6 +3071,20 @@
       "originalValue": "{!SPACING_XXL}",
       "name": "SPACING_XXL"
     },
+    "SPACING_XXXXL": {
+      "type": "size",
+      "category": "spacings",
+      "value": "96",
+      "originalValue": "{!SPACING_XXXXL}",
+      "name": "SPACING_XXXXL"
+    },
+    "SPACING_MD": {
+      "type": "size",
+      "category": "spacings",
+      "value": "8",
+      "originalValue": "{!SPACING_MD}",
+      "name": "SPACING_MD"
+    },
     "SPACING_NONE": {
       "type": "size",
       "category": "spacings",
@@ -3086,12 +3092,26 @@
       "originalValue": "{!SPACING_NONE}",
       "name": "SPACING_NONE"
     },
+    "SPACING_SM": {
+      "type": "size",
+      "category": "spacings",
+      "value": "4",
+      "originalValue": "{!SPACING_SM}",
+      "name": "SPACING_SM"
+    },
     "SPACING_ICON_TEXT": {
       "type": "size",
       "category": "spacings",
       "value": "8",
       "originalValue": "{!SPACING_MD}",
       "name": "SPACING_ICON_TEXT"
+    },
+    "SPACING_LG": {
+      "type": "size",
+      "category": "spacings",
+      "value": "24",
+      "originalValue": "{!SPACING_LG}",
+      "name": "SPACING_LG"
     },
     "TOUCHABLE_OVERLAY_OPACITY": {
       "category": "touchables",
@@ -4397,14 +4417,16 @@
     "CAROUSEL_INDICATOR_DOT_SIZE_SM",
     "CAROUSEL_INDICATOR_DOT_SIZE_MD",
     "CAROUSEL_INDICATOR_DOT_SIZE_BASE",
-    "SPACING_SM",
-    "SPACING_MD",
     "SPACING_BASE",
-    "SPACING_LG",
+    "SPACING_XXXL",
     "SPACING_XL",
     "SPACING_XXL",
+    "SPACING_XXXXL",
+    "SPACING_MD",
     "SPACING_NONE",
+    "SPACING_SM",
     "SPACING_ICON_TEXT",
+    "SPACING_LG",
     "TOUCHABLE_OVERLAY_OPACITY",
     "FONT_FAMILY_LARKEN",
     "TEXT_XXXL_LETTER_SPACING",


### PR DESCRIPTION
This PR adds additional spacing values that we missing for Android and iOS 


Remember to include the following changes:

- [ ] `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated for changes to tokens and icons
