### PR TITLE
Add PRIVATE_SWITCH_ON_CONTRAST_OFF token (web only)

### DIFF
--- a/packages/bpk-foundations-web/src/base.json
+++ b/packages/bpk-foundations-web/src/base.json
@@ -17,6 +17,7 @@
     "./base/panels.json",
     "./base/sliders.json",
     "./base/spacing.json",
+    "./base/switch.json",
     "./base/typography.json",
     "./base/z-index.json"
   ]

--- a/packages/bpk-foundations-web/src/base/switch.json
+++ b/packages/bpk-foundations-web/src/base/switch.json
@@ -1,0 +1,17 @@
+{
+  "imports": [
+    "./aliases.json"
+  ],
+  "global": {
+    "type": "color",
+    "category": "switch-colors"
+  },
+  "props": {
+    "PRIVATE_SWITCH_ON_CONTRAST_OFF_DAY": {
+      "value": "{!WHITE_ALPHA_20}"
+    },
+    "PRIVATE_SWITCH_ON_CONTRAST_OFF_NIGHT": {
+      "value": "{!WHITE_ALPHA_20}"
+    }
+  }
+}

--- a/packages/bpk-foundations-web/tokens/base.common.js
+++ b/packages/bpk-foundations-web/tokens/base.common.js
@@ -381,6 +381,8 @@ module.exports = {
   onePixelRem: ".0625rem",
   spacingNone: "0",
   spacingIconText: ".5rem",
+  privateSwitchOnContrastOffDay: "rgba(255, 255, 255, 0.2)",
+  privateSwitchOnContrastOffNight: "rgba(255, 255, 255, 0.2)",
   fontWeightBook: "400",
   lineHeightXlTight: "1.75rem",
   lineHeightXxxxxl: "4rem",

--- a/packages/bpk-foundations-web/tokens/base.default.scss
+++ b/packages/bpk-foundations-web/tokens/base.default.scss
@@ -761,6 +761,10 @@ $bpk-spacing-icon-text: .5rem !default;
 @function bpk-spacing-xl() { @return 2rem; }
 /// @group spacings
 @function bpk-spacing-xxxl() { @return 4rem; }
+/// @group switch-colors
+$bpk-private-switch-on-contrast-off-day: rgba(255, 255, 255, 0.2) !default;
+/// @group switch-colors
+$bpk-private-switch-on-contrast-off-night: rgba(255, 255, 255, 0.2) !default;
 /// @group font-weights
 $bpk-font-weight-book: 400 !default;
 /// @group typesettings

--- a/packages/bpk-foundations-web/tokens/base.es6.d.ts
+++ b/packages/bpk-foundations-web/tokens/base.es6.d.ts
@@ -379,6 +379,8 @@ export declare const privateSliderSelectedDay = "rgb(21, 70, 121)" as const;
 export declare const onePixelRem = ".0625rem" as const;
 export declare const spacingNone = "0" as const;
 export declare const spacingIconText = ".5rem" as const;
+export declare const privateSwitchOnContrastOffDay = "rgba(255, 255, 255, 0.2)" as const;
+export declare const privateSwitchOnContrastOffNight = "rgba(255, 255, 255, 0.2)" as const;
 export declare const fontWeightBook = "400" as const;
 export declare const lineHeightXlTight = "1.75rem" as const;
 export declare const lineHeightXxxxxl = "4rem" as const;
@@ -835,6 +837,10 @@ surfaceHighlightNight,
 surfaceLowContrastDay,
 surfaceSubtleDay,
 surfaceHighlightDay,
+} as const;
+export declare const switchColors = {
+privateSwitchOnContrastOffDay,
+privateSwitchOnContrastOffNight,
 } as const;
 export declare const textColors = {
 textOnDarkDay,

--- a/packages/bpk-foundations-web/tokens/base.es6.js
+++ b/packages/bpk-foundations-web/tokens/base.es6.js
@@ -379,6 +379,8 @@ export const privateSliderSelectedDay = "rgb(21, 70, 121)";
 export const onePixelRem = ".0625rem";
 export const spacingNone = "0";
 export const spacingIconText = ".5rem";
+export const privateSwitchOnContrastOffDay = "rgba(255, 255, 255, 0.2)";
+export const privateSwitchOnContrastOffNight = "rgba(255, 255, 255, 0.2)";
 export const fontWeightBook = "400";
 export const lineHeightXlTight = "1.75rem";
 export const lineHeightXxxxxl = "4rem";
@@ -835,6 +837,10 @@ surfaceHighlightNight,
 surfaceLowContrastDay,
 surfaceSubtleDay,
 surfaceHighlightDay,
+};
+export const switchColors = {
+privateSwitchOnContrastOffDay,
+privateSwitchOnContrastOffNight,
 };
 export const textColors = {
 textOnDarkDay,

--- a/packages/bpk-foundations-web/tokens/base.raw.json
+++ b/packages/bpk-foundations-web/tokens/base.raw.json
@@ -3159,6 +3159,20 @@
       "originalValue": "@function bpk-spacing-xxxl() { @return {!SPACING_XXXL}; }",
       "name": "SPACING_FUNCTION_XXXL"
     },
+    "PRIVATE_SWITCH_ON_CONTRAST_OFF_DAY": {
+      "type": "color",
+      "category": "switch-colors",
+      "value": "rgba(255, 255, 255, 0.2)",
+      "originalValue": "{!WHITE_ALPHA_20}",
+      "name": "PRIVATE_SWITCH_ON_CONTRAST_OFF_DAY"
+    },
+    "PRIVATE_SWITCH_ON_CONTRAST_OFF_NIGHT": {
+      "type": "color",
+      "category": "switch-colors",
+      "value": "rgba(255, 255, 255, 0.2)",
+      "originalValue": "{!WHITE_ALPHA_20}",
+      "name": "PRIVATE_SWITCH_ON_CONTRAST_OFF_NIGHT"
+    },
     "FONT_WEIGHT_BOOK": {
       "value": "400",
       "type": "string",

--- a/packages/bpk-foundations-web/tokens/base.scss
+++ b/packages/bpk-foundations-web/tokens/base.scss
@@ -761,6 +761,10 @@ $bpk-spacing-icon-text: .5rem;
 @function bpk-spacing-xl() { @return 2rem; }
 /// @group spacings
 @function bpk-spacing-xxxl() { @return 4rem; }
+/// @group switch-colors
+$bpk-private-switch-on-contrast-off-day: rgba(255, 255, 255, 0.2);
+/// @group switch-colors
+$bpk-private-switch-on-contrast-off-night: rgba(255, 255, 255, 0.2);
 /// @group font-weights
 $bpk-font-weight-book: 400;
 /// @group typesettings


### PR DESCRIPTION
Adds a new web-only private token `PRIVATE_SWITCH_ON_CONTRAST_OFF` (DAY/NIGHT) for `BpkSwitch`, set to `rgba(255, 255, 255, 0.20)` via the `WHITE_ALPHA_20` alias. Source lives in a new `packages/bpk-foundations-web/src/base/switch.json` with category `switch-colors`; generated `tokens/*` outputs were rebuilt via `npm run tokens`. Not propagated to common, iOS, or Android per scope.

Remember to include the following changes:

- [ ] `README.md`
- [ ] Tests
- [ ] Storybook examples created/updated for changes to tokens and icons