### PR TITLE
fix(formatters): escape backslashes before quotes in token string literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
         "statements": 75
       }
     },
-    "testRegex": "packages/.*-test\\.js$",
+    "testRegex": "packages/.*-test\\.[cm]?js$",
     "transform": {
-      "^.+\\.js$": "babel-jest"
+      "^.+\\.[cm]?js$": "babel-jest"
     },
     "transformIgnorePatterns": [
       "node_modules/(?!bpk|color)"

--- a/packages/bpk-foundations-web/formatters/bpk.common.js.mjs
+++ b/packages/bpk-foundations-web/formatters/bpk.common.js.mjs
@@ -33,9 +33,9 @@ export const tokenTemplate = ({ name, type, value }) => {
     tokenValue = performTokenOperations(value);
   }
 
-  return `${_.camelCase(name)}: "${tokenValue
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')}"`;
+  return `${_.camelCase(name)}: ${JSON.stringify(tokenValue)
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')}`;
 };
 
 export default (result) => {

--- a/packages/bpk-foundations-web/formatters/bpk.common.js.mjs
+++ b/packages/bpk-foundations-web/formatters/bpk.common.js.mjs
@@ -33,7 +33,9 @@ export const tokenTemplate = ({ name, type, value }) => {
     tokenValue = performTokenOperations(value);
   }
 
-  return `${_.camelCase(name)}: "${tokenValue.replace(/"/g, '\\"')}"`;
+  return `${_.camelCase(name)}: "${tokenValue
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')}"`;
 };
 
 export default (result) => {

--- a/packages/bpk-foundations-web/formatters/bpk.common.js.mjs
+++ b/packages/bpk-foundations-web/formatters/bpk.common.js.mjs
@@ -33,7 +33,10 @@ export const tokenTemplate = ({ name, type, value }) => {
     tokenValue = performTokenOperations(value);
   }
 
-  return `${_.camelCase(name)}: ${JSON.stringify(tokenValue)
+  // Coerce to a string before serialising: token values are always strings
+  // here, and String() keeps a non-string value (e.g. a number) from being
+  // emitted as a bare, unquoted literal that would change the output shape.
+  return `${_.camelCase(name)}: ${JSON.stringify(String(tokenValue))
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029')}`;
 };

--- a/packages/bpk-foundations-web/formatters/bpk.d.ts.mjs
+++ b/packages/bpk-foundations-web/formatters/bpk.d.ts.mjs
@@ -32,8 +32,11 @@ export const tokenTemplate = ({ name, type, value }) => {
   if (/\+|\*/.test(value)) {
     tokenValue = performTokenOperations(value);
   }
+  // Coerce to a string before serialising: token values are always strings
+  // here, and String() keeps a non-string value (e.g. a number) from being
+  // emitted as a bare, unquoted literal that would change the output shape.
   return `export declare const ${_.camelCase(name)} = ${JSON.stringify(
-    tokenValue,
+    String(tokenValue),
   )
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029')} as const;`;

--- a/packages/bpk-foundations-web/formatters/bpk.d.ts.mjs
+++ b/packages/bpk-foundations-web/formatters/bpk.d.ts.mjs
@@ -32,9 +32,11 @@ export const tokenTemplate = ({ name, type, value }) => {
   if (/\+|\*/.test(value)) {
     tokenValue = performTokenOperations(value);
   }
-  return `export declare const ${_.camelCase(name)} = "${tokenValue
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')}" as const;`;
+  return `export declare const ${_.camelCase(name)} = ${JSON.stringify(
+    tokenValue,
+  )
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')} as const;`;
 };
 
 export const categoryTemplate = (

--- a/packages/bpk-foundations-web/formatters/bpk.d.ts.mjs
+++ b/packages/bpk-foundations-web/formatters/bpk.d.ts.mjs
@@ -32,10 +32,9 @@ export const tokenTemplate = ({ name, type, value }) => {
   if (/\+|\*/.test(value)) {
     tokenValue = performTokenOperations(value);
   }
-  return `export declare const ${_.camelCase(name)} = "${tokenValue.replace(
-    /"/g,
-    '\\"',
-  )}" as const;`;
+  return `export declare const ${_.camelCase(name)} = "${tokenValue
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')}" as const;`;
 };
 
 export const categoryTemplate = (

--- a/packages/bpk-foundations-web/formatters/bpk.es6.js.mjs
+++ b/packages/bpk-foundations-web/formatters/bpk.es6.js.mjs
@@ -32,9 +32,9 @@ export const tokenTemplate = ({ name, type, value }) => {
   if (/\+|\*/.test(value)) {
     tokenValue = performTokenOperations(value);
   }
-  return `export const ${_.camelCase(name)} = "${tokenValue
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')}";`;
+  return `export const ${_.camelCase(name)} = ${JSON.stringify(tokenValue)
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')};`;
 };
 
 export const categoryTemplate = (

--- a/packages/bpk-foundations-web/formatters/bpk.es6.js.mjs
+++ b/packages/bpk-foundations-web/formatters/bpk.es6.js.mjs
@@ -32,7 +32,12 @@ export const tokenTemplate = ({ name, type, value }) => {
   if (/\+|\*/.test(value)) {
     tokenValue = performTokenOperations(value);
   }
-  return `export const ${_.camelCase(name)} = ${JSON.stringify(tokenValue)
+  // Coerce to a string before serialising: token values are always strings
+  // here, and String() keeps a non-string value (e.g. a number) from being
+  // emitted as a bare, unquoted literal that would change the output shape.
+  return `export const ${_.camelCase(name)} = ${JSON.stringify(
+    String(tokenValue),
+  )
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029')};`;
 };

--- a/packages/bpk-foundations-web/formatters/bpk.es6.js.mjs
+++ b/packages/bpk-foundations-web/formatters/bpk.es6.js.mjs
@@ -32,10 +32,9 @@ export const tokenTemplate = ({ name, type, value }) => {
   if (/\+|\*/.test(value)) {
     tokenValue = performTokenOperations(value);
   }
-  return `export const ${_.camelCase(name)} = "${tokenValue.replace(
-    /"/g,
-    '\\"',
-  )}";`;
+  return `export const ${_.camelCase(name)} = "${tokenValue
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')}";`;
 };
 
 export const categoryTemplate = (

--- a/packages/bpk-foundations-web/formatters/escaping-test.mjs
+++ b/packages/bpk-foundations-web/formatters/escaping-test.mjs
@@ -16,9 +16,17 @@
  * limitations under the License.
  */
 
-import { tokenTemplate as es6TokenTemplate } from './bpk.es6.js.mjs';
-import { tokenTemplate as dtsTokenTemplate } from './bpk.d.ts.mjs';
-import { tokenTemplate as commonTokenTemplate } from './bpk.common.js.mjs';
+import es6Formatter, {
+  tokenTemplate as es6TokenTemplate,
+  categoryTemplate as es6CategoryTemplate,
+} from './bpk.es6.js.mjs';
+import dtsFormatter, {
+  tokenTemplate as dtsTokenTemplate,
+  categoryTemplate as dtsCategoryTemplate,
+} from './bpk.d.ts.mjs';
+import commonFormatter, {
+  tokenTemplate as commonTokenTemplate,
+} from './bpk.common.js.mjs';
 
 const LINE_SEPARATOR = String.fromCharCode(0x2028);
 const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
@@ -27,7 +35,9 @@ const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
 // either break the string literal (line terminators) or silently corrupt the
 // emitted value. This is the class of `js/incomplete-sanitization` the fix
 // guards against, so no generated snippet should contain them raw.
-const RAW_UNSAFE = new RegExp(`[\\n\\r${LINE_SEPARATOR}${PARAGRAPH_SEPARATOR}]`);
+const RAW_UNSAFE = new RegExp(
+  `[\\n\\r${LINE_SEPARATOR}${PARAGRAPH_SEPARATOR}]`,
+);
 
 // Hostile token values that previously broke or corrupted the generated
 // module (see CodeQL alerts #4, #5, #6).
@@ -94,6 +104,88 @@ describe('token string literal escaping', () => {
 
         expect(roundTrip(line, formatter)).toEqual('8');
       });
+
+      it('returns null for a function token', () => {
+        expect(
+          template({ name: 'token', type: 'function', value: 'fn()' }),
+        ).toBeNull();
+      });
+
+      it('resolves token operations before escaping', () => {
+        const line = template({
+          name: 'token',
+          type: 'size',
+          value: '1rem + 2.5rem',
+        });
+
+        expect(roundTrip(line, formatter)).toEqual('3.5rem');
+      });
     });
+  });
+});
+
+describe('categoryTemplate', () => {
+  const props = [
+    { name: 'brand-color-primary', category: 'colors' },
+    { name: 'brand-color-secondary', category: 'colors' },
+  ];
+
+  it('groups camelCased token names for the es6 formatter', () => {
+    expect(es6CategoryTemplate('colors', props)).toEqual(
+      'export const colors = {\nbrandColorPrimary,\nbrandColorSecondary,\n};',
+    );
+  });
+
+  it('groups camelCased token names for the d.ts formatter', () => {
+    expect(dtsCategoryTemplate('colors', props)).toEqual(
+      'export declare const colors = {\n' +
+        'brandColorPrimary,\nbrandColorSecondary,\n} as const;',
+    );
+  });
+});
+
+describe('default formatter', () => {
+  // Minimal stand-in for the theo result object the formatters consume.
+  const result = {
+    toJS: () => ({
+      props: [
+        {
+          name: 'brand-color',
+          category: 'colors',
+          type: 'color',
+          value: 'red',
+        },
+        { name: 'ignored', category: 'misc', type: 'function', value: 'fn()' },
+      ],
+    }),
+  };
+
+  it('emits single tokens and grouped categories for es6', () => {
+    const output = es6Formatter(result);
+
+    expect(output).toContain('export const brandColor = "red";');
+    expect(output).toContain('export const colors = {\nbrandColor,\n};');
+    // Function tokens are excluded from the output.
+    expect(output).not.toContain('ignored');
+  });
+
+  it('emits declarations and grouped categories for d.ts', () => {
+    const output = dtsFormatter(result);
+
+    expect(output).toContain(
+      'export declare const brandColor = "red" as const;',
+    );
+    expect(output).toContain(
+      'export declare const colors = {\nbrandColor,\n} as const;',
+    );
+    expect(output).not.toContain('ignored');
+  });
+
+  it('emits a CommonJS module map for common', () => {
+    const output = commonFormatter(result);
+
+    expect(output).toContain('module.exports = {');
+    expect(output).toContain('brandColor: "red"');
+    expect(output).not.toContain('ignored');
   });
 });

--- a/packages/bpk-foundations-web/formatters/escaping-test.mjs
+++ b/packages/bpk-foundations-web/formatters/escaping-test.mjs
@@ -1,0 +1,99 @@
+/*
+ * Backpack - Skyscanner's Design System
+ *
+ * Copyright 2016-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { tokenTemplate as es6TokenTemplate } from './bpk.es6.js.mjs';
+import { tokenTemplate as dtsTokenTemplate } from './bpk.d.ts.mjs';
+import { tokenTemplate as commonTokenTemplate } from './bpk.common.js.mjs';
+
+const LINE_SEPARATOR = String.fromCharCode(0x2028);
+const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
+
+// Any of these characters appearing unescaped in the generated source would
+// either break the string literal (line terminators) or silently corrupt the
+// emitted value. This is the class of `js/incomplete-sanitization` the fix
+// guards against, so no generated snippet should contain them raw.
+const RAW_UNSAFE = new RegExp(`[\\n\\r${LINE_SEPARATOR}${PARAGRAPH_SEPARATOR}]`);
+
+// Hostile token values that previously broke or corrupted the generated
+// module (see CodeQL alerts #4, #5, #6).
+const HOSTILE_VALUES = {
+  'trailing backslash': 'foo\\',
+  'embedded backslash': 'back\\slash',
+  'embedded double quote': 'he said "hi"',
+  newline: 'a\nb',
+  'carriage return': 'a\rb',
+  tab: 'a\tb',
+  'line separator (U+2028)': `a${LINE_SEPARATOR}b`,
+  'paragraph separator (U+2029)': `a${PARAGRAPH_SEPARATOR}b`,
+  'null character': `a${String.fromCharCode(0)}b`,
+  combined: `foo\\"bar\n${LINE_SEPARATOR}`,
+};
+
+// Strip a generated line down to just the value literal so it can be evaluated
+// back into the original JavaScript value.
+const extractLiteral = (line, formatter) => {
+  switch (formatter) {
+    case 'es6':
+      return line.replace(/^export const \w+ = /, '').replace(/;$/, '');
+    case 'd.ts':
+      return line
+        .replace(/^export declare const \w+ = /, '')
+        .replace(/ as const;$/, '');
+    case 'common':
+      return line.replace(/^\w+: /, '');
+    default:
+      throw new Error(`Unknown formatter ${formatter}`);
+  }
+};
+
+const roundTrip = (line, formatter) =>
+  // eslint-disable-next-line no-eval
+  eval(`(${extractLiteral(line, formatter)})`);
+
+describe('token string literal escaping', () => {
+  const formatters = [
+    { name: 'es6', template: es6TokenTemplate },
+    { name: 'd.ts', template: dtsTokenTemplate },
+    { name: 'common', template: commonTokenTemplate },
+  ];
+
+  formatters.forEach(({ name: formatter, template }) => {
+    describe(`${formatter} formatter`, () => {
+      Object.entries(HOSTILE_VALUES).forEach(([description, value]) => {
+        const line = template({ name: 'token', type: 'color', value });
+
+        it(`round-trips a value containing a ${description}`, () => {
+          expect(roundTrip(line, formatter)).toEqual(value);
+        });
+
+        it(`emits no raw line terminators for a ${description}`, () => {
+          expect(RAW_UNSAFE.test(line)).toBe(false);
+        });
+      });
+
+      // Token values are always strings, but a non-string value must still be
+      // emitted as a quoted string literal rather than a bare, unquoted value
+      // that would silently change the generated output shape.
+      it('emits a quoted string literal for a non-string value', () => {
+        const line = template({ name: 'token', type: 'color', value: 8 });
+
+        expect(roundTrip(line, formatter)).toEqual('8');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What this solves

CodeQL code scanning alerts [#4](https://github.com/Skyscanner/backpack-foundations/security/code-scanning/4), [#5](https://github.com/Skyscanner/backpack-foundations/security/code-scanning/5), [#6](https://github.com/Skyscanner/backpack-foundations/security/code-scanning/6): `js/incomplete-sanitization` (security severity: **high**).

The three web token formatters emit JS/TS string literals from token values but only escaped double quotes — **not backslashes** or other characters that are significant in a string literal:

```js
tokenValue.replace(/"/g, '\\"')
```

Because the input isn't fully sanitized, a token value could break out of or corrupt the generated string literal:

- A **trailing backslash** (`foo\`) produced **invalid syntax**, breaking the generated module.
- An **embedded backslash** (`back\slash`) was emitted verbatim, **silently changing the value** on parse.
- **Line terminators** (`\n`, `\r`, U+2028, U+2029) would also break the literal.

Affected files (same issue in each):
- `packages/bpk-foundations-web/formatters/bpk.es6.js.mjs` (#6)
- `packages/bpk-foundations-web/formatters/bpk.d.ts.mjs` (#5)
- `packages/bpk-foundations-web/formatters/bpk.common.js.mjs` (#4)

The iOS/Android formatters serialise the whole object with `JSON.stringify` and the SCSS formatters don't emit JS/TS literals, so they don't carry this issue — these three web formatters were the only hand-rolled JS/TS literal emitters.

## What changed

Generate each string literal with `JSON.stringify` instead of hand-rolled escaping, so the full set of required escapes (backslash, quote, newline, CR, control chars) is handled consistently:

```js
JSON.stringify(String(tokenValue))
  .replace(/ /g, '\\u2028')
  .replace(/ /g, '\\u2029')
```

- `JSON.stringify` emits U+2028/U+2029 raw (they are valid in JSON but are line terminators in JS source), so those two are post-escaped.
- `String(tokenValue)` coerces the value first: token values are always strings today, and this keeps a non-string value from being emitted as a bare, unquoted literal that would silently change the output shape.

## Tests

Adds `formatters/escaping-test.mjs`, which runs each formatter's `tokenTemplate` against hostile inputs — trailing/embedded backslash, double quote, `\n`, `\r`, tab, U+2028, U+2029, NUL, combined, and a non-string value — asserting that every value round-trips and no raw line terminator leaks into the generated source.

The jest `testRegex`/`transform` are widened to include `.mjs`/`.cjs`, since the config previously matched only `.js` and formatter tests (including the existing `utils-test.mjs`) were not being collected.

## Verification

- ✅ `node --check` passes on all three formatters and the test file
- ✅ Round-trip check across all hostile inputs: old escaping throws a syntax error or corrupts/leaks; new escaping round-trips correctly and leaks no raw line terminator in every case
- ✅ Non-string value (`8`) is emitted as the quoted literal `"8"` rather than a bare `8`