### PR TITLE
ci: set explicit minimal GITHUB_TOKEN permissions for build and label-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   label-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What this solves

CodeQL code scanning alerts [#1](https://github.com/Skyscanner/backpack-foundations/security/code-scanning/1) and [#2](https://github.com/Skyscanner/backpack-foundations/security/code-scanning/2): `actions/missing-workflow-permissions` (security severity: **medium**).

The `build` job in `ci.yml` and the `label-check` workflow did not declare an explicit `permissions` block, so their `GITHUB_TOKEN` defaulted to the broad repository-level scope.

## What changed

- **`ci.yml`**: added `permissions: { contents: read }` to the `build` job. The `ReleaseDraft` job keeps its existing `permissions` block, untouched.
- **`label-check.yml`**: added a top-level `permissions: { contents: read }`.