### PR TITLE
Add explicit permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ defaults:
 
 jobs:
   release:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     environment: Publishing
 


### PR DESCRIPTION
## Summary
To fix the security alert: https://github.com/Skyscanner/backpack-foundations/security/code-scanning/3, this workflow is using github app tokne and npm token thus limiting the scope of github_token would not affect the current workflow
- add an explicit `contents: read` permission to the release job
- limit the default `GITHUB_TOKEN` scope and resolve CodeQL `actions/missing-workflow-permissions`

## Testing
- `git diff --check`